### PR TITLE
Fix the enabled flag with provided options for react queries

### DIFF
--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -396,7 +396,7 @@ export function useSg721CollectionInfoQuery({
   options
 }: Sg721CollectionInfoQuery) {
   return useQuery<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client?.contractAddress], () => client ? client.collectionInfo() : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721MinterQuery {
@@ -408,7 +408,7 @@ export function useSg721MinterQuery({
   options
 }: Sg721MinterQuery) {
   return useQuery<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client?.contractAddress], () => client ? client.minter() : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721AllTokensQuery {
@@ -428,7 +428,7 @@ export function useSg721AllTokensQuery({
     limit: args.limit,
     startAfter: args.startAfter
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721TokensQuery {
@@ -450,7 +450,7 @@ export function useSg721TokensQuery({
     owner: args.owner,
     startAfter: args.startAfter
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721AllNftInfoQuery {
@@ -470,7 +470,7 @@ export function useSg721AllNftInfoQuery({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721NftInfoQuery {
@@ -488,7 +488,7 @@ export function useSg721NftInfoQuery({
   return useQuery<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>([\\"sg721NftInfo\\", client?.contractAddress], () => client ? client.nftInfo({
     tokenId: args.tokenId
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721ContractInfoQuery {
@@ -500,7 +500,7 @@ export function useSg721ContractInfoQuery({
   options
 }: Sg721ContractInfoQuery) {
   return useQuery<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client?.contractAddress], () => client ? client.contractInfo() : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721NumTokensQuery {
@@ -512,7 +512,7 @@ export function useSg721NumTokensQuery({
   options
 }: Sg721NumTokensQuery) {
   return useQuery<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client?.contractAddress], () => client ? client.numTokens() : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721AllOperatorsQuery {
@@ -536,7 +536,7 @@ export function useSg721AllOperatorsQuery({
     owner: args.owner,
     startAfter: args.startAfter
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721ApprovalsQuery {
@@ -556,7 +556,7 @@ export function useSg721ApprovalsQuery({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721ApprovalQuery {
@@ -578,7 +578,7 @@ export function useSg721ApprovalQuery({
     spender: args.spender,
     tokenId: args.tokenId
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
 export interface Sg721OwnerOfQuery {
@@ -598,7 +598,7 @@ export function useSg721OwnerOfQuery({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
   }) : undefined, { ...options,
-    enabled: !!client && options?.enabled
+    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }"
 `;

--- a/packages/wasm-ast-types/src/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query.ts
@@ -173,12 +173,25 @@ export const createReactQueryHook = ({
                                                     '!',
                                                     t.unaryExpression('!', t.identifier('client'))
                                                 ),
-                                                t.optionalMemberExpression(
-                                                    t.identifier('options'),
-                                                    t.identifier('enabled'),
-                                                    false,
-                                                    true
+                                                t.conditionalExpression(
+                                                    // explicitly check for undefined
+                                                    t.binaryExpression(
+                                                        '!=',
+                                                        t.optionalMemberExpression(
+                                                            t.identifier('options'),
+                                                            t.identifier('enabled'),
+                                                            false,
+                                                            true
+                                                        ),
+                                                        t.identifier('undefined')
+                                                    ),
+                                                    t.memberExpression(
+                                                        t.identifier('options'),
+                                                        t.identifier('enabled')
+                                                    ),
+                                                    t.booleanLiteral(true)
                                                 )
+
                                             )),
                                     ])
                                     : t.identifier('options'),


### PR DESCRIPTION
This change fixes an incorrect react-query code generation in [#31](https://github.com/CosmWasm/ts-codegen/pull/31) that would disable queries if the options were provided without an enabled flag.

Before:
```ts
enabled: !!client && options?.enabled // if not options, will always be disabled because the rhs will return undefined
```

After:
```ts
{
   // explicitly check for undefined because of the optional chain
   enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
}
```