### PR TITLE
Feature/use mutation

### DIFF
--- a/packages/ts-codegen/__tests__/cosmwasmts.test.ts
+++ b/packages/ts-codegen/__tests__/cosmwasmts.test.ts
@@ -14,6 +14,20 @@ it('optionalClient', async () => {
     await reactQuery('Factory', schemas, outopt, { optionalClient: true });
 })
 
+it('v4Query', async () => {
+    const outopt = OUTPUT_DIR + '/vectis/factory-opt';
+    const schemaDir = FIXTURE_DIR + '/vectis/factory/';
+    const schemas = readSchemas({ schemaDir, argv: {} });
+    await reactQuery('Factory', schemas, outopt, { v4: true });
+})
+
+it('useMutations', async () => {
+    const outopt = OUTPUT_DIR + '/vectis/factory-opt';
+    const schemaDir = FIXTURE_DIR + '/vectis/factory/';
+    const schemas = readSchemas({ schemaDir, argv: {} });
+    await reactQuery('Factory', schemas, outopt, { v4: true, mutations: true });
+})
+
 it('vectis/factory', async () => {
     const out = OUTPUT_DIR + '/vectis/factory';
     const outopt = OUTPUT_DIR + '/vectis/factory-opt';

--- a/packages/ts-codegen/src/commands/react-query.ts
+++ b/packages/ts-codegen/src/commands/react-query.ts
@@ -36,6 +36,12 @@ export default async (argv) => {
             name: 'v4',
             message: 'Use react-query v4?',
             default: false
+        },
+        {
+            type: 'confirm',
+            name: 'mutations',
+            message: 'Geneate useMutation hooks? Must be used with v4.',
+            default: false
         }
     ];
 

--- a/packages/ts-codegen/src/generate.ts
+++ b/packages/ts-codegen/src/generate.ts
@@ -8,7 +8,8 @@ import { writeFileSync } from 'fs';
 import generate from "@babel/generator";
 import { clean } from "./clean";
 import { getMessageProperties } from "wasm-ast-types";
-import { findAndParseTypes, findExecuteMsg, findQueryMsg } from "./utils";
+import { findAndParseTypes, findExecuteMsg, findQueryMsg } from './utils';
+import { cosmjsAminoImportStatements } from './imports';
 
 export default async (name: string, schemas: any[], outPath: string) => {
 
@@ -28,16 +29,7 @@ export default async (name: string, schemas: any[], outPath: string) => {
     w.importStmt(['CosmWasmClient', 'ExecuteResult', 'SigningCosmWasmClient'], '@cosmjs/cosmwasm-stargate')
   );
 
-  if (typeHash.hasOwnProperty('Coin')) {
-    body.push(
-      w.importStmt(['StdFee'], '@cosmjs/amino')
-    );
-  } else {
-    body.push(
-      w.importStmt(['Coin', 'StdFee'], '@cosmjs/amino')
-    );
-  }
-
+  body.push(cosmjsAminoImportStatements(typeHash));
 
   // TYPES
   Object.values(typeHash).forEach(type => {

--- a/packages/ts-codegen/src/imports.ts
+++ b/packages/ts-codegen/src/imports.ts
@@ -1,0 +1,12 @@
+import * as w from 'wasm-ast-types';
+
+export const cosmjsAminoImportStatements = (typeHash) => {
+  const cosmjsImports = ['StdFee'];
+
+  // If the coin is not provided by the generation already, import it from cosmjs
+  if (!typeHash.hasOwnProperty('Coin')) {
+    cosmjsImports.unshift('Coin');
+  }
+
+  return w.importStmt(cosmjsImports, '@cosmjs/amino');
+};

--- a/packages/ts-codegen/src/index.ts
+++ b/packages/ts-codegen/src/index.ts
@@ -3,4 +3,4 @@ export { default as fromPartial } from './from-partial';
 export { default as reactQuery } from './react-query';
 export { default as recoil } from './recoil';
 export * from './utils';
-export { cosmjsAminoImportStatements } from './imports';
+export * from './imports';

--- a/packages/ts-codegen/src/index.ts
+++ b/packages/ts-codegen/src/index.ts
@@ -3,3 +3,4 @@ export { default as fromPartial } from './from-partial';
 export { default as reactQuery } from './react-query';
 export { default as recoil } from './recoil';
 export * from './utils';
+export { cosmjsAminoImportStatements } from './imports';

--- a/packages/ts-codegen/src/react-query.ts
+++ b/packages/ts-codegen/src/react-query.ts
@@ -6,52 +6,75 @@ import * as w from 'wasm-ast-types';
 import * as t from '@babel/types';
 import { writeFileSync } from 'fs';
 import generate from "@babel/generator";
-import { findAndParseTypes, findQueryMsg } from "./utils";
-import { ReactQueryOptions } from "wasm-ast-types";
+import { findAndParseTypes, findExecuteMsg, findQueryMsg } from "./utils";
+import { getMessageProperties, ReactQueryOptions } from "wasm-ast-types";
 
 
 
-export default async (name: string, schemas: any[], outPath: string, options?: ReactQueryOptions) => {
+export default async (contractName: string, schemas: any[], outPath: string, options?: ReactQueryOptions) => {
 
-    const ReactQueryFile = pascal(`${name}Contract`) + '.react-query.ts';
-    const Contract = pascal(`${name}Contract`)
+    const ReactQueryFile = pascal(`${contractName}Contract`) + '.react-query.ts';
+    const Contract = pascal(`${contractName}Contract`)
 
     const QueryMsg = findQueryMsg(schemas);
+    const ExecuteMsg = findExecuteMsg(schemas);
     const typeHash = await findAndParseTypes(schemas);
 
-    let QueryClient = null;
-    let ReadOnlyInstance = null;
+    const ExecuteClient = pascal(`${contractName}Client`);
+    const QueryClient = pascal(`${contractName}QueryClient`);
 
     const body = [];
 
+    const reactQueryImports = ['useQuery', 'UseQueryOptions']
+    const clientImports = []
+
+    QueryMsg && clientImports.push(QueryClient)
+
+    // check that there are commands within the exec msg
+    const shouldGenerateMutationHooks = ExecuteMsg && options?.mutations && options?.v4 && getMessageProperties(ExecuteMsg).length > 0
+
+    if (shouldGenerateMutationHooks) {
+        body.push(w.importStmt(['ExecuteResult'], '@cosmjs/cosmwasm-stargate'));
+        reactQueryImports.push(...['UseMutationOptions', 'useMutation'])
+        clientImports.push(ExecuteClient)
+    }
+
+    // react-query imports
     body.push(
-        w.importStmt(['useQuery', 'UseQueryOptions'], options?.v4 ? '@tanstack/react-query' : 'react-query')
+        w.importStmt(reactQueryImports, options?.v4 ? '@tanstack/react-query' : 'react-query')
     );
 
-    body.push(
-        w.importStmt(Object.keys(typeHash), `./${Contract}`)
-    );
+    // general contract imports
+    body.push(w.importStmt(Object.keys(typeHash), `./${Contract}`));
+
+    // client imports
+    body.push(w.importStmt(clientImports, `./${Contract}`));
+
 
     // query messages
     if (QueryMsg) {
-
-        QueryClient = pascal(`${name}QueryClient`);
-        ReadOnlyInstance = pascal(`${name}ReadOnlyInterface`);
-
-        body.push(
-            w.importStmt([QueryClient], `./${Contract}`)
-        );
-
         [].push.apply(body,
             w.createReactQueryHooks({
                 queryMsg: QueryMsg,
-                contractName: name,
+                contractName: contractName,
                 QueryClient,
                 options
             })
         );
-
     }
+
+    if (shouldGenerateMutationHooks) {
+        [].push.apply(body,
+            w.createReactQueryMutationHooks({
+                execMsg: ExecuteMsg,
+                contractName: contractName,
+                ExecuteClient,
+                options
+            })
+        );
+    }
+
+
 
     const code = header + generate(
         t.program(body)

--- a/packages/ts-codegen/src/react-query.ts
+++ b/packages/ts-codegen/src/react-query.ts
@@ -35,6 +35,7 @@ export default async (contractName: string, schemas: any[], outPath: string, opt
 
     if (shouldGenerateMutationHooks) {
         body.push(w.importStmt(['ExecuteResult'], '@cosmjs/cosmwasm-stargate'));
+        body.push(w.importStmt(['Coin', 'StdFee'], '@cosmjs/amino'))
         reactQueryImports.push(...['UseMutationOptions', 'useMutation'])
         clientImports.push(ExecuteClient)
     }

--- a/packages/ts-codegen/src/react-query.ts
+++ b/packages/ts-codegen/src/react-query.ts
@@ -6,8 +6,9 @@ import * as w from 'wasm-ast-types';
 import * as t from '@babel/types';
 import { writeFileSync } from 'fs';
 import generate from "@babel/generator";
-import { findAndParseTypes, findExecuteMsg, findQueryMsg } from "./utils";
+import { findAndParseTypes, findExecuteMsg, findQueryMsg } from './utils';
 import { getMessageProperties, ReactQueryOptions } from "wasm-ast-types";
+import { cosmjsAminoImportStatements } from './imports';
 
 
 
@@ -31,12 +32,12 @@ export default async (contractName: string, schemas: any[], outPath: string, opt
     QueryMsg && clientImports.push(QueryClient)
 
     // check that there are commands within the exec msg
-    const shouldGenerateMutationHooks = ExecuteMsg && options?.mutations && options?.v4 && getMessageProperties(ExecuteMsg).length > 0
+    const shouldGenerateMutationHooks = ExecuteMsg && options?.v4 && options?.mutations && getMessageProperties(ExecuteMsg).length > 0
 
     if (shouldGenerateMutationHooks) {
         body.push(w.importStmt(['ExecuteResult'], '@cosmjs/cosmwasm-stargate'));
-        body.push(w.importStmt(['Coin', 'StdFee'], '@cosmjs/amino'))
-        reactQueryImports.push(...['UseMutationOptions', 'useMutation'])
+        body.push(cosmjsAminoImportStatements(typeHash))
+        reactQueryImports.push('useMutation', 'UseMutationOptions')
         clientImports.push(ExecuteClient)
     }
 

--- a/packages/ts-codegen/src/utils.ts
+++ b/packages/ts-codegen/src/utils.ts
@@ -2,7 +2,7 @@ import { sync as glob } from 'glob';
 import { readFileSync } from 'fs';
 import { cleanse } from './cleanse';
 import { compile } from 'json-schema-to-typescript';
-import { parser } from "./parse";
+import { parser } from './parse';
 
 export const readSchemas = ({
     schemaDir, argv, clean = true
@@ -49,3 +49,4 @@ export const findAndParseTypes = async (schemas) => {
     const typeHash = parser(allTypes);
     return typeHash;
 }
+

--- a/packages/ts-codegen/types/react-query.d.ts
+++ b/packages/ts-codegen/types/react-query.d.ts
@@ -1,2 +1,2 @@
-declare const _default: (name: string, schemas: any[], outPath: string, options?: { optionalClient?: boolean, v4?: boolean }) => Promise<void>;
+declare const _default: (name: string, schemas: any[], outPath: string, options?: { optionalClient?: boolean, v4?: boolean, mutations?: boolean }) => Promise<void>;
 export default _default;

--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -1067,7 +1067,7 @@ exports[`createReactQueryHooks 6`] = `
   msg: {
     tokenId: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1081,13 +1081,13 @@ export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteRe
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.burn(msg, fee, memo, funds), options);
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
   msg: MintMsgForEmpty;
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1101,7 +1101,7 @@ export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteRe
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.mint(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeAllMutation {
@@ -1109,7 +1109,7 @@ export interface Sg721RevokeAllMutation {
   msg: {
     operator: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1123,7 +1123,7 @@ export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<Exec
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.revokeAll(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveAllMutation {
@@ -1132,7 +1132,7 @@ export interface Sg721ApproveAllMutation {
     expires?: Expiration;
     operator: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1146,7 +1146,7 @@ export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<Exe
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.approveAll(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeMutation {
@@ -1155,7 +1155,7 @@ export interface Sg721RevokeMutation {
     spender: string;
     tokenId: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1169,7 +1169,7 @@ export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<Execute
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.revoke(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveMutation {
@@ -1179,7 +1179,7 @@ export interface Sg721ApproveMutation {
     spender: string;
     tokenId: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1193,7 +1193,7 @@ export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<Execut
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.approve(msg, fee, memo, funds), options);
 }
 export interface Sg721SendNftMutation {
@@ -1203,7 +1203,7 @@ export interface Sg721SendNftMutation {
     msg: Binary;
     tokenId: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1217,7 +1217,7 @@ export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<Execut
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.sendNft(msg, fee, memo, funds), options);
 }
 export interface Sg721TransferNftMutation {
@@ -1226,7 +1226,7 @@ export interface Sg721TransferNftMutation {
     recipient: string;
     tokenId: string;
   };
-  args: {
+  args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
     funds?: readonly Coin[];
@@ -1240,7 +1240,7 @@ export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<Ex
       fee,
       memo,
       funds
-    }
+    } = {}
   }) => client.transferNft(msg, fee, memo, funds), options);
 }"
 `;

--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -1064,103 +1064,183 @@ export function useSg721OwnerOfQuery({
 exports[`createReactQueryHooks 6`] = `
 "export interface Sg721BurnMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     tokenId: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721BurnMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721BurnMutation>(({
     client,
-    args
-  }) => client.burn(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.burn(msg, fee, memo, funds), options);
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
-  args: MintMsgForEmpty;
+  msg: MintMsgForEmpty;
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
+  };
 }
 export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721MintMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721MintMutation>(({
     client,
-    args
-  }) => client.mint(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.mint(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeAllMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     operator: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeAllMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721RevokeAllMutation>(({
     client,
-    args
-  }) => client.revokeAll(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.revokeAll(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveAllMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     expires?: Expiration;
     operator: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveAllMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721ApproveAllMutation>(({
     client,
-    args
-  }) => client.approveAll(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.approveAll(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     spender: string;
     tokenId: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721RevokeMutation>(({
     client,
-    args
-  }) => client.revoke(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.revoke(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     expires?: Expiration;
     spender: string;
     tokenId: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721ApproveMutation>(({
     client,
-    args
-  }) => client.approve(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.approve(msg, fee, memo, funds), options);
 }
 export interface Sg721SendNftMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     contract: string;
     msg: Binary;
     tokenId: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721SendNftMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721SendNftMutation>(({
     client,
-    args
-  }) => client.sendNft(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.sendNft(msg, fee, memo, funds), options);
 }
 export interface Sg721TransferNftMutation {
   client: Sg721Client;
-  args: {
+  msg: {
     recipient: string;
     tokenId: string;
+  };
+  args: {
+    fee?: number | StdFee | \\"auto\\";
+    memo?: string;
+    funds?: readonly Coin[];
   };
 }
 export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721TransferNftMutation>, \\"mutationFn\\">) {
   return useMutation<ExecuteResult, Error, Sg721TransferNftMutation>(({
     client,
-    args
-  }) => client.transferNft(args), options);
+    msg,
+    args: {
+      fee,
+      memo,
+      funds
+    }
+  }) => client.transferNft(msg, fee, memo, funds), options);
 }"
 `;

--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -1064,126 +1064,102 @@ export function useSg721OwnerOfQuery({
 exports[`createReactQueryHooks 6`] = `
 "export interface Sg721BurnMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721BurnMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     tokenId: string;
   };
 }
-export function useSg721BurnMutation({
-  client,
-  options
-}: Omit<Sg721BurnMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721BurnMutation, \\"args\\">>(({
+export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721BurnMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721BurnMutation>(({
+    client,
     args
   }) => client.burn(args), options);
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721MintMutation, \\"args\\">>, \\"mutationFn\\">;
   args: MintMsgForEmpty;
 }
-export function useSg721MintMutation({
-  client,
-  options
-}: Omit<Sg721MintMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721MintMutation, \\"args\\">>(({
+export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721MintMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721MintMutation>(({
+    client,
     args
   }) => client.mint(args), options);
 }
 export interface Sg721RevokeAllMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721RevokeAllMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     operator: string;
   };
 }
-export function useSg721RevokeAllMutation({
-  client,
-  options
-}: Omit<Sg721RevokeAllMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721RevokeAllMutation, \\"args\\">>(({
+export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeAllMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721RevokeAllMutation>(({
+    client,
     args
   }) => client.revokeAll(args), options);
 }
 export interface Sg721ApproveAllMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721ApproveAllMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     expires?: Expiration;
     operator: string;
   };
 }
-export function useSg721ApproveAllMutation({
-  client,
-  options
-}: Omit<Sg721ApproveAllMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721ApproveAllMutation, \\"args\\">>(({
+export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveAllMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721ApproveAllMutation>(({
+    client,
     args
   }) => client.approveAll(args), options);
 }
 export interface Sg721RevokeMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721RevokeMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     spender: string;
     tokenId: string;
   };
 }
-export function useSg721RevokeMutation({
-  client,
-  options
-}: Omit<Sg721RevokeMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721RevokeMutation, \\"args\\">>(({
+export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721RevokeMutation>(({
+    client,
     args
   }) => client.revoke(args), options);
 }
 export interface Sg721ApproveMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721ApproveMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     expires?: Expiration;
     spender: string;
     tokenId: string;
   };
 }
-export function useSg721ApproveMutation({
-  client,
-  options
-}: Omit<Sg721ApproveMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721ApproveMutation, \\"args\\">>(({
+export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721ApproveMutation>(({
+    client,
     args
   }) => client.approve(args), options);
 }
 export interface Sg721SendNftMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721SendNftMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     contract: string;
     msg: Binary;
     tokenId: string;
   };
 }
-export function useSg721SendNftMutation({
-  client,
-  options
-}: Omit<Sg721SendNftMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721SendNftMutation, \\"args\\">>(({
+export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721SendNftMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721SendNftMutation>(({
+    client,
     args
   }) => client.sendNft(args), options);
 }
 export interface Sg721TransferNftMutation {
   client: Sg721Client;
-  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721TransferNftMutation, \\"args\\">>, \\"mutationFn\\">;
   args: {
     recipient: string;
     tokenId: string;
   };
 }
-export function useSg721TransferNftMutation({
-  client,
-  options
-}: Omit<Sg721TransferNftMutation, \\"args\\">) {
-  return useMutation<ExecuteResult, Error, Pick<Sg721TransferNftMutation, \\"args\\">>(({
+export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721TransferNftMutation>, \\"mutationFn\\">) {
+  return useMutation<ExecuteResult, Error, Sg721TransferNftMutation>(({
+    client,
     args
   }) => client.transferNft(args), options);
 }"

--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -1060,3 +1060,131 @@ export function useSg721OwnerOfQuery({
   });
 }"
 `;
+
+exports[`createReactQueryHooks 6`] = `
+"export interface Sg721BurnMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721BurnMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    tokenId: string;
+  };
+}
+export function useSg721BurnMutation({
+  client,
+  options
+}: Omit<Sg721BurnMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721BurnMutation, \\"args\\">>(({
+    args
+  }) => client.burn(args), options);
+}
+export interface Sg721MintMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721MintMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {};
+}
+export function useSg721MintMutation({
+  client,
+  options
+}: Omit<Sg721MintMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721MintMutation, \\"args\\">>(({
+    args
+  }) => client.mint(args), options);
+}
+export interface Sg721RevokeAllMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721RevokeAllMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    operator: string;
+  };
+}
+export function useSg721RevokeAllMutation({
+  client,
+  options
+}: Omit<Sg721RevokeAllMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721RevokeAllMutation, \\"args\\">>(({
+    args
+  }) => client.revokeAll(args), options);
+}
+export interface Sg721ApproveAllMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721ApproveAllMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    expires?: Expiration;
+    operator: string;
+  };
+}
+export function useSg721ApproveAllMutation({
+  client,
+  options
+}: Omit<Sg721ApproveAllMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721ApproveAllMutation, \\"args\\">>(({
+    args
+  }) => client.approveAll(args), options);
+}
+export interface Sg721RevokeMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721RevokeMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    spender: string;
+    tokenId: string;
+  };
+}
+export function useSg721RevokeMutation({
+  client,
+  options
+}: Omit<Sg721RevokeMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721RevokeMutation, \\"args\\">>(({
+    args
+  }) => client.revoke(args), options);
+}
+export interface Sg721ApproveMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721ApproveMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    expires?: Expiration;
+    spender: string;
+    tokenId: string;
+  };
+}
+export function useSg721ApproveMutation({
+  client,
+  options
+}: Omit<Sg721ApproveMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721ApproveMutation, \\"args\\">>(({
+    args
+  }) => client.approve(args), options);
+}
+export interface Sg721SendNftMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721SendNftMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    contract: string;
+    msg: Binary;
+    tokenId: string;
+  };
+}
+export function useSg721SendNftMutation({
+  client,
+  options
+}: Omit<Sg721SendNftMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721SendNftMutation, \\"args\\">>(({
+    args
+  }) => client.sendNft(args), options);
+}
+export interface Sg721TransferNftMutation {
+  client: Sg721Client;
+  options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721TransferNftMutation, \\"args\\">>, \\"mutationFn\\">;
+  args: {
+    recipient: string;
+    tokenId: string;
+  };
+}
+export function useSg721TransferNftMutation({
+  client,
+  options
+}: Omit<Sg721TransferNftMutation, \\"args\\">) {
+  return useMutation<ExecuteResult, Error, Pick<Sg721TransferNftMutation, \\"args\\">>(({
+    args
+  }) => client.transferNft(args), options);
+}"
+`;

--- a/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/__snapshots__/react-query.spec.ts.snap
@@ -1080,7 +1080,7 @@ export function useSg721BurnMutation({
 export interface Sg721MintMutation {
   client: Sg721Client;
   options?: Omit<UseMutationOptions<ExecuteResult, Error, Pick<Sg721MintMutation, \\"args\\">>, \\"mutationFn\\">;
-  args: {};
+  args: MintMsgForEmpty;
 }
 export function useSg721MintMutation({
   client,

--- a/packages/wasm-ast-types/src/react-query.spec.ts
+++ b/packages/wasm-ast-types/src/react-query.spec.ts
@@ -18,7 +18,8 @@ import tokens_response from './../../../__fixtures__/basic/tokens_response.json'
 
 import {
   createReactQueryHook,
-  createReactQueryHooks
+  createReactQueryHooks,
+  createReactQueryMutationHooks,
 } from './react-query'
 
 const expectCode = (ast) => {
@@ -86,6 +87,14 @@ it('createReactQueryHooks', () => {
         contractName: 'Sg721',
         QueryClient: 'Sg721QueryClient',
         options: { optionalClient: true, v4: true }
+      }
+    )))
+  expectCode(t.program(
+    createReactQueryMutationHooks(
+      {
+        execMsg: execute_msg,
+        contractName: 'Sg721',
+        ExecuteClient: 'Sg721Client',
       }
     )))
 });

--- a/packages/wasm-ast-types/src/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query.ts
@@ -306,17 +306,20 @@ export const createReactQueryMutationArgsInterface = ({
 
   //  fee: number | StdFee | "auto" = "auto", memo?: string, funds?: readonly Coin[]
 
-  body.push(
-    t.tsPropertySignature(
-      t.identifier('args'),
-      t.tsTypeAnnotation(
-        t.tsTypeLiteral(FIXED_EXECUTE_PARAMS.map(param => propertySignature(
-          param.name,
-          param.typeAnnotation,
-          param.optional
-        )))
-      )
-  ))
+  const optionalArgs = t.tsPropertySignature(
+    t.identifier('args'),
+    t.tsTypeAnnotation(
+      t.tsTypeLiteral(FIXED_EXECUTE_PARAMS.map(param => propertySignature(
+        param.name,
+        param.typeAnnotation,
+        param.optional
+      )))
+    )
+  )
+
+  optionalArgs.optional = true
+
+  body.push(optionalArgs)
 
 
     return t.exportNamedDeclaration(t.tsInterfaceDeclaration(
@@ -438,7 +441,12 @@ export const createReactQueryMutationHook = ({
   useMutationFunctionArgs.push(
     t.objectProperty(
       t.identifier('args'),
-      t.objectPattern(FIXED_EXECUTE_PARAMS.map(param => shorthandProperty(param.name)))))
+      t.assignmentPattern(
+        t.objectPattern(FIXED_EXECUTE_PARAMS.map(param => shorthandProperty(param.name))),
+        t.objectExpression([])
+      )
+    )
+  )
 
     return t.exportNamedDeclaration(
         t.functionDeclaration(

--- a/packages/wasm-ast-types/src/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query.ts
@@ -11,6 +11,7 @@ import { typeRefOrOptionalUnion, propertySignature, optionalConditionalExpressio
 import { getPropertyType } from './utils/types';
 import type { Expression } from '@babel/types'
 
+// TODO: this mutations boolean is not actually used here and only at a higher level
 export interface ReactQueryOptions {
     optionalClient?: boolean
     v4?: boolean
@@ -240,6 +241,22 @@ interface ReactQueryMutationHookInterface {
     useMutationTypeParameter: t.TSTypeParameterInstantiation
 }
 
+/**
+ * Example:
+```
+export interface Cw4UpdateMembersMutation {
+  client: Cw4GroupClient
+  args: {
+    tokenId: string
+    remove: string[]
+  }
+  options?: Omit<
+    UseMutationOptions<ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>,
+    'mutationFn'
+  >
+}
+```
+ */
 export const createReactQueryMutationArgsInterface = ({
     ExecuteClient,
     mutationHookParamsTypeName,
@@ -340,6 +357,7 @@ export const createReactQueryMutationHooks = ({
                 );
             });
 
+            // <ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>
             const useMutationTypeParameter = t.tsTypeParameterInstantiation([
                 // Data
                 t.tSTypeReference(
@@ -378,28 +396,6 @@ export const createReactQueryMutationHooks = ({
 };
 
 
-
-/*
-export interface Cw4UpdateMembersMutation {
-  client: Cw4GroupClient
-  args: {
-    tokenId: string
-    remove: string[]
-  }
-  options?: Omit<
-    UseMutationOptions<ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>,
-    'mutationFn'
-  >
-}
-
-export const useCw4UpdateMembersMutation = ({ client, options }: Omit<Cw4UpdateMembersMutation, 'args'>) =>
-  useMutation<ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>(
-    ({ args }) => client.updateMembers(args),
-    options
-  )
-
-*/
-
 interface ReactQueryMutationHook {
     mutationHookName: string;
     mutationHookParamsTypeName: string;
@@ -408,6 +404,17 @@ interface ReactQueryMutationHook {
     execArgs: t.ObjectProperty[]
 }
 
+/**
+ *
+ * Example:
+```
+export const useCw4UpdateMembersMutation = ({ client, options }: Omit<Cw4UpdateMembersMutation, 'args'>) =>
+  useMutation<ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>(
+    ({ args }) => client.updateMembers(args),
+    options
+  )
+```
+ */
 export const createReactQueryMutationHook = ({
     mutationHookName,
     mutationHookParamsTypeName,
@@ -511,6 +518,7 @@ export const createReactQueryMutationHook = ({
     )
 
 };
+
 
 interface ReactQueryHookQueryInterface {
     QueryClient: string;

--- a/packages/wasm-ast-types/src/utils/babel.ts
+++ b/packages/wasm-ast-types/src/utils/babel.ts
@@ -3,6 +3,8 @@ import { snake } from "case";
 import { Field, QueryMsg, ExecuteMsg } from '../types';
 import { TSTypeAnnotation, TSExpressionWithTypeArguments } from '@babel/types';
 
+
+// t.TSPropertySignature - kind?
 export const propertySignature = (
     name: string,
     typeAnnotation: t.TSTypeAnnotation,
@@ -16,7 +18,7 @@ export const propertySignature = (
     }
 };
 
-export const identifier = (name: string, typeAnnotation: t.TSTypeAnnotation, optional: boolean = false) => {
+export const identifier = (name: string, typeAnnotation: t.TSTypeAnnotation, optional: boolean = false): t.Identifier => {
     const type = t.identifier(name);
     type.typeAnnotation = typeAnnotation;
     type.optional = optional;
@@ -276,3 +278,27 @@ export const typeRefOrOptionalUnion = (identifier: t.Identifier, optional: boole
         : typeReference
 }
 
+export const parameterizedTypeReference = (identifier: string, from: t.TSType, omit: string | Array<string>) => {
+    return t.tsTypeReference(
+        t.identifier(identifier),
+        t.tsTypeParameterInstantiation([
+            from,
+            typeof omit === 'string'
+                ? t.tsLiteralType(t.stringLiteral(omit))
+                : t.tsUnionType(omit.map(o => t.tsLiteralType(t.stringLiteral(o))))
+        ])
+    )
+}
+
+/**
+ * omitTypeReference(t.tsTypeReference(t.identifier('Cw4UpdateMembersMutation'),),'args').....
+ * Omit<Cw4UpdateMembersMutation, 'args'>
+ */
+export const omitTypeReference = (from: t.TSType, omit: string | Array<string>) => {
+    return parameterizedTypeReference('Omit', from, omit)
+}
+
+
+export const pickTypeReference = (from: t.TSType, pick: string | Array<string>) => {
+    return parameterizedTypeReference('Pick', from, pick)
+}

--- a/packages/wasm-ast-types/src/utils/types.ts
+++ b/packages/wasm-ast-types/src/utils/types.ts
@@ -1,6 +1,7 @@
 import * as t from '@babel/types';
 import { camel } from 'case';
 import { propertySignature } from './babel';
+import { TSTypeAnnotation } from '@babel/types';
 
 const getTypeStrFromRef = ($ref) => {
     switch ($ref) {
@@ -14,7 +15,7 @@ const getTypeStrFromRef = ($ref) => {
     }
 }
 
-const getTypeFromRef = ($ref) => {
+export const getTypeFromRef = ($ref) => {
     switch ($ref) {
         case '#/definitions/Binary':
             return t.tsTypeReference(t.identifier('Binary'))
@@ -156,7 +157,7 @@ export const getPropertyType = (schema, prop) => {
     return { type, optional };
 };
 
-function extracted(jsonschema: any, prop: string, camelize: boolean) {
+export function getPropertySignatureFromProp(jsonschema: any, prop: string, camelize: boolean) {
   if (jsonschema.properties[prop].type === 'object') {
     if (jsonschema.properties[prop].title) {
       return propertySignature(
@@ -257,13 +258,27 @@ function extracted(jsonschema: any, prop: string, camelize: boolean) {
   );
 }
 
+export const getParamsTypeAnnotation = (jsonschema: any, camelize: boolean = true): t.TSTypeAnnotation => {
+  const keys = Object.keys(jsonschema.properties ?? {});
+  if (!keys.length) return undefined;
+
+  const typedParams = keys.map(prop => getPropertySignatureFromProp(jsonschema, prop, camelize));
+
+  return t.tsTypeAnnotation(
+    t.tsTypeLiteral(
+      [
+        ...typedParams
+      ]
+    )
+  )
+}
+
 export const createTypedObjectParams = (jsonschema: any, camelize: boolean = true): t.ObjectPattern => {
     const keys = Object.keys(jsonschema.properties ?? {});
     if (!keys.length) return;
 
-    const typedParams = keys.map(prop => {
-      return extracted(jsonschema, prop, camelize);
-    });
+  // const typedParams = keys.map(prop => getPropertySignatureFromProp(jsonschema, prop, camelize));
+
     const params = keys.map(prop => {
         return t.objectProperty(
             camelize ? t.identifier(camel(prop)) : t.identifier(prop),
@@ -278,13 +293,15 @@ export const createTypedObjectParams = (jsonschema: any, camelize: boolean = tru
             ...params
         ]
     );
-    obj.typeAnnotation = t.tsTypeAnnotation(
-        t.tsTypeLiteral(
-            [
-                ...typedParams
-            ]
-        )
-    );
+
+    obj.typeAnnotation = getParamsTypeAnnotation(jsonschema, camelize)
+    // obj.typeAnnotation = t.tsTypeAnnotation(
+    //     t.tsTypeLiteral(
+    //         [
+    //             ...typedParams
+    //         ]
+    //     )
+    // );
 
     return obj;
 };

--- a/packages/wasm-ast-types/src/utils/types.ts
+++ b/packages/wasm-ast-types/src/utils/types.ts
@@ -295,13 +295,6 @@ export const createTypedObjectParams = (jsonschema: any, camelize: boolean = tru
     );
 
     obj.typeAnnotation = getParamsTypeAnnotation(jsonschema, camelize)
-    // obj.typeAnnotation = t.tsTypeAnnotation(
-    //     t.tsTypeLiteral(
-    //         [
-    //             ...typedParams
-    //         ]
-    //     )
-    // );
 
     return obj;
 };

--- a/packages/wasm-ast-types/src/wasm.ts
+++ b/packages/wasm-ast-types/src/wasm.ts
@@ -163,6 +163,43 @@ export const createQueryClass = (
   );
 }
 
+export const CONSTANT_EXEC_PARAMS = [
+  t.assignmentPattern(
+    identifier(
+      'fee',
+      t.tsTypeAnnotation(
+        t.tsUnionType(
+          [
+            t.tSNumberKeyword(),
+            t.tsTypeReference(
+              t.identifier('StdFee')
+            ),
+            t.tsLiteralType(
+              t.stringLiteral('auto')
+            )
+          ]
+        )
+      ),
+      false
+    ),
+    t.stringLiteral('auto')
+  ),
+  identifier('memo', t.tsTypeAnnotation(
+    t.tsStringKeyword()
+  ), true),
+  identifier('funds', t.tsTypeAnnotation(
+    tsTypeOperator(
+      t.tsArrayType(
+        t.tsTypeReference(
+          t.identifier('Coin')
+        )
+      ),
+      'readonly'
+    )
+  ), true)
+];
+
+
 export const createWasmExecMethod = (
   jsonschema: any
 ) => {
@@ -180,41 +217,7 @@ export const createWasmExecMethod = (
     );
   });
 
-  const constantParams = [
-    t.assignmentPattern(
-      identifier(
-        'fee',
-        t.tsTypeAnnotation(
-          t.tsUnionType(
-            [
-              t.tSNumberKeyword(),
-              t.tsTypeReference(
-                t.identifier('StdFee')
-              ),
-              t.tsLiteralType(
-                t.stringLiteral('auto')
-              )
-            ]
-          )
-        ),
-        false
-      ),
-      t.stringLiteral('auto')
-    ),
-    identifier('memo', t.tsTypeAnnotation(
-      t.tsStringKeyword()
-    ), true),
-    identifier('funds', t.tsTypeAnnotation(
-      tsTypeOperator(
-        t.tsArrayType(
-          t.tsTypeReference(
-            t.identifier('Coin')
-          )
-        ),
-        'readonly'
-      )
-    ), true)
-  ];
+
 
   return t.classProperty(
     t.identifier(methodName),
@@ -222,8 +225,8 @@ export const createWasmExecMethod = (
       obj ? [
         // props
         obj,
-        ...constantParams
-      ] : constantParams,
+        ...CONSTANT_EXEC_PARAMS
+      ] : CONSTANT_EXEC_PARAMS,
       t.blockStatement(
         [
           t.returnStatement(
@@ -465,44 +468,46 @@ export const createPropertyFunctionWithObjectParams = (methodName: string, respo
   );
 };
 
+export const FIXED_EXECUTE_PARAMS = [
+  identifier('fee', t.tsTypeAnnotation(
+    t.tsUnionType(
+      [
+        t.tsNumberKeyword(),
+        t.tsTypeReference(
+          t.identifier('StdFee')
+        ),
+        t.tsLiteralType(
+          t.stringLiteral('auto')
+        )
+      ]
+    )
+  ), true),
+  identifier('memo', t.tsTypeAnnotation(
+    t.tsStringKeyword()
+  ), true),
+  identifier('funds', t.tsTypeAnnotation(
+    tsTypeOperator(
+      t.tsArrayType(
+        t.tsTypeReference(
+          t.identifier('Coin')
+        )
+      ),
+      'readonly'
+    )
+  ), true)
+];
+
 export const createPropertyFunctionWithObjectParamsForExec = (methodName: string, responseType: string, jsonschema: any) => {
   const obj = createTypedObjectParams(jsonschema);
-  const fixedParams = [
-    identifier('fee', t.tsTypeAnnotation(
-      t.tsUnionType(
-        [
-          t.tsNumberKeyword(),
-          t.tsTypeReference(
-            t.identifier('StdFee')
-          ),
-          t.tsLiteralType(
-            t.stringLiteral('auto')
-          )
-        ]
-      )
-    ), true),
-    identifier('memo', t.tsTypeAnnotation(
-      t.tsStringKeyword()
-    ), true),
-    identifier('funds', t.tsTypeAnnotation(
-      tsTypeOperator(
-        t.tsArrayType(
-          t.tsTypeReference(
-            t.identifier('Coin')
-          )
-        ),
-        'readonly'
-      )
-    ), true)
-  ];
+
   const func = {
     type: 'TSFunctionType',
     typeAnnotation: promiseTypeAnnotation(responseType),
     parameters: obj ? [
       obj,
-      ...fixedParams
+      ...FIXED_EXECUTE_PARAMS
 
-    ] : fixedParams
+    ] : FIXED_EXECUTE_PARAMS
   }
 
   return t.tSPropertySignature(

--- a/packages/wasm-ast-types/types/react-query.d.ts
+++ b/packages/wasm-ast-types/types/react-query.d.ts
@@ -1,5 +1,5 @@
 import * as t from '@babel/types';
-import { QueryMsg } from './types';
+import { QueryMsg, ExecuteMsg } from './types';
 
 interface ReactQueryHooks {
     queryMsg: QueryMsg
@@ -19,6 +19,7 @@ interface ReactQueryHookQuery {
 export declare interface ReactQueryOptions {
     optionalClient?: boolean
     v4?: boolean
+    mutations?: boolean
 }
 export declare const createReactQueryHooks: ({ queryMsg, contractName, QueryClient, options }: ReactQueryHooks) => any;
 export declare const createReactQueryHook: ({ hookName, hookParamsTypeName, responseType, hookKeyName, methodName, jsonschema }: ReactQueryHookQuery) => t.ExportNamedDeclaration;
@@ -29,4 +30,41 @@ interface ReactQueryHookQueryInterface {
     jsonschema: any;
 }
 export declare const createReactQueryHookInterface: ({ QueryClient, hookParamsTypeName, responseType, jsonschema }: ReactQueryHookQueryInterface) => t.ExportNamedDeclaration;
+
+interface ReactQueryMutationHooks {
+    execMsg: ExecuteMsg
+    contractName: string
+    ExecuteClient: string
+    options?: ReactQueryOptions
+}
+export declare const createReactQueryMutationHooks: ({ execMsg, contractName, ExecuteClient, options }: ReactQueryMutationHooks) => any
+
+interface ReactQueryMutationHook {
+    mutationHookName: string;
+    mutationHookParamsTypeName: string;
+    execMethodName: string;
+    execArgs: t.ObjectProperty[]
+    options?: ReactQueryOptions
+}
+
+export declare const createReactQueryMutationHook: ({
+    mutationHookName,
+    mutationHookParamsTypeName,
+    execMethodName,
+    execArgs,
+    options,
+}: ReactQueryMutationHook) => any
+
+interface ReactQueryMutationHookInterface {
+    ExecuteClient: string
+    mutationHookParamsTypeName: string;
+    jsonschema: any
+}
+
+export declare const createReactQueryMutationArgsInterface: ({
+    ExecuteClient,
+    mutationHookParamsTypeName,
+    jsonschema
+}: ReactQueryMutationHookInterface) => t.ExportNamedDeclaration;
+
 export { };


### PR DESCRIPTION
This PR introduces generation for react-query [mutations](https://tanstack.com/query/v4/docs/guides/mutations). 

An example mutation from CW4Group is generated as follows:

```ts
export interface Cw3FlexMultisigProposeMutation {
  client: Cw3FlexMultisigClient;
  msg: {
    description: string;
    latest?: Expiration;
    msgs: CosmosMsgForEmpty[];
    title: string;
  };
  args: {
    fee?: number | StdFee | "auto";
    memo?: string;
    funds?: readonly Coin[];
  };
}
export function useCw3FlexMultisigProposeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Cw3FlexMultisigProposeMutation>, "mutationFn">) {
  return useMutation<ExecuteResult, Error, Cw3FlexMultisigProposeMutation>(({
    client,
    msg,
    args: {
      fee,
      memo,
      funds
    }
  }) => client.propose(msg, fee, memo, funds), options);
}
```

Using this hook would look like:
```ts
const { signingClient, address } = useWallet() // ex
const multisigClient = new Cw3FlexMultisigClient(signingClient, address, '<multisigAddress>')

const proposeMutation = useCw3FlexMultisigProposeMutation({ 
  onSettled: (data, error, _, __) => toastExecuteResult(data, error)
  onSuccess: console.log
})

const onSubmit = (values) => {
  // advised not to use mutateAsync because then error handling is your job
  // https://tkdodo.eu/blog/mastering-mutations-in-react-query#mutate-or-mutateasync
  proposeMutation.mutate({ 
    client: multisigClient,
    msg: values,
    // these are all optional
    args: {
      
      fee: '0.0025',
      funds: [{ denom: 'meepmorp', amount: '100' }],
      memo: 'This is a transaction',
    }
})
}


return (<form .......onSubmit={onSubmit}>
    ...
    {/* redundant, but just an example */}
    {mutation.isError && (<div>Proposal failure : {proposeMutation.error.message}</div>)}
    <Button type="submit" isLoading={proposeMutation.isLoading} />
  </form>
```

Note: this PR already has changes from #35 so will need to wait until that one is merged.