### PR TITLE
Add a type alias for the ExecuteMsg of generated contracts

### DIFF
--- a/__output__/cosmwasm/CW4GroupContract.ts
+++ b/__output__/cosmwasm/CW4GroupContract.ts
@@ -75,6 +75,7 @@ export interface MemberResponse {
 export interface HooksResponse {
   hooks: string[];
 }
+export type CW4GroupExecuteMsg = ExecuteMsg;
 export interface CW4GroupReadOnlyInterface {
   contractAddress: string;
   admin: () => Promise<AdminResponse>;

--- a/__output__/daodao/cw-admin-factory/CwAdminFactoryContract.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactoryContract.ts
@@ -19,6 +19,7 @@ export interface InstantiateMsg {
   [k: string]: unknown;
 }
 export type QueryMsg = string;
+export type CwAdminFactoryExecuteMsg = ExecuteMsg;
 export interface CwAdminFactoryReadOnlyInterface {
   contractAddress: string;
 }

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistryContract.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistryContract.ts
@@ -109,6 +109,7 @@ export type ReceiveMsg = {
     version: string;
   };
 };
+export type CwCodeIdRegistryExecuteMsg = ExecuteMsg;
 export interface CwCodeIdRegistryReadOnlyInterface {
   contractAddress: string;
   config: () => Promise<ConfigResponse>;

--- a/__output__/daodao/cw-named-groups/CwNamedGroupsContract.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroupsContract.ts
@@ -71,6 +71,7 @@ export type QueryMsg = {
     [k: string]: unknown;
   };
 };
+export type CwNamedGroupsExecuteMsg = ExecuteMsg;
 export interface CwNamedGroupsReadOnlyInterface {
   contractAddress: string;
   dump: () => Promise<DumpResponse>;

--- a/__output__/daodao/cw-proposal-single/CwProposalSingleContract.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingleContract.ts
@@ -416,6 +416,7 @@ export interface VoteResponse {
   vote?: VoteInfo | null;
   [k: string]: unknown;
 }
+export type CwProposalSingleExecuteMsg = ExecuteMsg;
 export interface CwProposalSingleReadOnlyInterface {
   contractAddress: string;
   config: () => Promise<ConfigResponse>;

--- a/__output__/minter/MinterContract.ts
+++ b/__output__/minter/MinterContract.ts
@@ -124,6 +124,7 @@ export type QueryMsg = {
     [k: string]: unknown;
   };
 };
+export type MinterExecuteMsg = ExecuteMsg;
 export interface MinterReadOnlyInterface {
   contractAddress: string;
   config: () => Promise<ConfigResponse>;

--- a/__output__/sg721/Sg721Contract.ts
+++ b/__output__/sg721/Sg721Contract.ts
@@ -232,6 +232,7 @@ export interface TokensResponse {
   tokens: string[];
   [k: string]: unknown;
 }
+export type Sg721ExecuteMsg = ExecuteMsg;
 export interface Sg721ReadOnlyInterface {
   contractAddress: string;
   ownerOf: ({

--- a/__output__/vectis/factory/FactoryContract.ts
+++ b/__output__/vectis/factory/FactoryContract.ts
@@ -183,6 +183,7 @@ export interface WalletsResponse {
   wallets: Addr[];
   [k: string]: unknown;
 }
+export type FactoryExecuteMsg = ExecuteMsg;
 export interface FactoryReadOnlyInterface {
   contractAddress: string;
   wallets: ({

--- a/__output__/vectis/govec/GovecContract.ts
+++ b/__output__/vectis/govec/GovecContract.ts
@@ -212,6 +212,7 @@ export type QueryMsg = {
   };
 };
 export type Uint64 = number;
+export type GovecExecuteMsg = ExecuteMsg;
 export interface GovecReadOnlyInterface {
   contractAddress: string;
   info: () => Promise<InfoResponse>;

--- a/__output__/vectis/proxy/ProxyContract.ts
+++ b/__output__/vectis/proxy/ProxyContract.ts
@@ -212,6 +212,7 @@ export type QueryMsg = {
   };
 };
 export type Uint64 = number;
+export type ProxyExecuteMsg = ExecuteMsg;
 export interface ProxyReadOnlyInterface {
   contractAddress: string;
   info: () => Promise<InfoResponse>;

--- a/packages/ts-codegen/src/generate.ts
+++ b/packages/ts-codegen/src/generate.ts
@@ -40,11 +40,22 @@ export default async (name: string, schemas: any[], outPath: string) => {
 
 
   // TYPES
-  Object.values(typeHash).forEach(type => {
+  Object.values(typeHash).forEach((type: t.Node) => {
     body.push(
       clean(type)
     )
   });
+
+  // alias the ExecuteMsg
+  ExecuteMsg && body.push(
+    t.exportNamedDeclaration(
+      t.tsTypeAliasDeclaration(
+        t.identifier(`${name}ExecuteMsg`),
+        null,
+        t.tsTypeReference(t.identifier('ExecuteMsg'))
+      )
+    )
+  )
 
 
   // query messages


### PR DESCRIPTION
This change adds a type alias from the ExecuteMsg to the name of the contract's ExecuteMsg.

For instance,
```ts
export type Cw20ExecuteMsg = ExecuteMsg
```

This means that we can import them more easily without aliasing them in the file.
