### PR TITLE
Cleanup the react-query queries generation

### DIFF
--- a/__output__/builder/default/CwAdminFactory.react-query.ts
+++ b/__output__/builder/default/CwAdminFactory.react-query.ts
@@ -4,5 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
+import { UseQueryOptions } from "react-query";
 import { ExecuteMsg, Binary, InstantiateMsg, QueryMsg } from "./CwAdminFactory.types";
 import { CwAdminFactoryQueryClient } from "./CwAdminFactory.client";
+export interface CwAdminFactoryReactQuery<TResponse> {
+  client: CwAdminFactoryQueryClient;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}

--- a/__output__/builder/default/CwCodeIdRegistry.react-query.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, PaymentInfo, Uint128, ConfigResponse, ExecuteMsg, Binary, Cw20ReceiveMsg, GetRegistrationResponse, Registration, InfoForCodeIdResponse, InstantiateMsg, ListRegistrationsResponse, QueryMsg, ReceiveMsg } from "./CwCodeIdRegistry.types";
 import { CwCodeIdRegistryQueryClient } from "./CwCodeIdRegistry.client";
-export interface CwCodeIdRegistryListRegistrationsQuery {
+export interface CwCodeIdRegistryReactQuery<TResponse> {
   client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ListRegistrationsResponse, Error, ListRegistrationsResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface CwCodeIdRegistryListRegistrationsQuery extends CwCodeIdRegistryReactQuery<ListRegistrationsResponse> {
   args: {
     chainId: string;
     name: string;
@@ -25,9 +27,7 @@ export function useCwCodeIdRegistryListRegistrationsQuery({
     name: args.name
   }), options);
 }
-export interface CwCodeIdRegistryInfoForCodeIdQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<InfoForCodeIdResponse, Error, InfoForCodeIdResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryInfoForCodeIdQuery extends CwCodeIdRegistryReactQuery<InfoForCodeIdResponse> {
   args: {
     chainId: string;
     codeId: number;
@@ -43,9 +43,7 @@ export function useCwCodeIdRegistryInfoForCodeIdQuery({
     codeId: args.codeId
   }), options);
 }
-export interface CwCodeIdRegistryGetRegistrationQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<GetRegistrationResponse, Error, GetRegistrationResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryGetRegistrationQuery extends CwCodeIdRegistryReactQuery<GetRegistrationResponse> {
   args: {
     chainId: string;
     name: string;
@@ -63,10 +61,7 @@ export function useCwCodeIdRegistryGetRegistrationQuery({
     version: args.version
   }), options);
 }
-export interface CwCodeIdRegistryConfigQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwCodeIdRegistryConfigQuery extends CwCodeIdRegistryReactQuery<ConfigResponse> {}
 export function useCwCodeIdRegistryConfigQuery({
   client,
   options

--- a/__output__/builder/default/CwSingle.react-query.ts
+++ b/__output__/builder/default/CwSingle.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, Uint128, Duration, Threshold, PercentageThreshold, Decimal, ConfigResponse, CheckedDepositInfo, ExecuteMsg, CosmosMsgForEmpty, BankMsg, StakingMsg, DistributionMsg, Binary, IbcMsg, Timestamp, Uint64, WasmMsg, GovMsg, VoteOption, Vote, DepositToken, Coin, Empty, IbcTimeout, IbcTimeoutBlock, DepositInfo, GovernanceModulesResponse, InfoResponse, ContractVersion, InstantiateMsg, Expiration, Status, ListProposalsResponse, ProposalResponse, Proposal, Votes, ListVotesResponse, VoteInfo, MigrateMsg, ProposalCountResponse, ProposalHooksResponse, QueryMsg, ReverseProposalsResponse, VoteHooksResponse, VoteResponse } from "./CwSingle.types";
 import { CwSingleQueryClient } from "./CwSingle.client";
-export interface CwSingleInfoQuery {
+export interface CwSingleReactQuery<TResponse> {
   client: CwSingleQueryClient;
-  options?: UseQueryOptions<InfoResponse, Error, InfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface CwSingleInfoQuery extends CwSingleReactQuery<InfoResponse> {}
 export function useCwSingleInfoQuery({
   client,
   options
 }: CwSingleInfoQuery) {
   return useQuery<InfoResponse, Error, InfoResponse, (string | undefined)[]>(["cwSingleInfo", client.contractAddress], () => client.info(), options);
 }
-export interface CwSingleVoteHooksQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>;
-}
+export interface CwSingleVoteHooksQuery extends CwSingleReactQuery<VoteHooksResponse> {}
 export function useCwSingleVoteHooksQuery({
   client,
   options
 }: CwSingleVoteHooksQuery) {
   return useQuery<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>(["cwSingleVoteHooks", client.contractAddress], () => client.voteHooks(), options);
 }
-export interface CwSingleProposalHooksQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>;
-}
+export interface CwSingleProposalHooksQuery extends CwSingleReactQuery<ProposalHooksResponse> {}
 export function useCwSingleProposalHooksQuery({
   client,
   options
 }: CwSingleProposalHooksQuery) {
   return useQuery<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>(["cwSingleProposalHooks", client.contractAddress], () => client.proposalHooks(), options);
 }
-export interface CwSingleListVotesQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ListVotesResponse, Error, ListVotesResponse, (string | undefined)[]>;
+export interface CwSingleListVotesQuery extends CwSingleReactQuery<ListVotesResponse> {
   args: {
     limit?: number;
     proposalId: number;
@@ -57,9 +50,7 @@ export function useCwSingleListVotesQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwSingleVoteQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<VoteResponse, Error, VoteResponse, (string | undefined)[]>;
+export interface CwSingleVoteQuery extends CwSingleReactQuery<VoteResponse> {
   args: {
     proposalId: number;
     voter: string;
@@ -75,19 +66,14 @@ export function useCwSingleVoteQuery({
     voter: args.voter
   }), options);
 }
-export interface CwSingleProposalCountQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>;
-}
+export interface CwSingleProposalCountQuery extends CwSingleReactQuery<ProposalCountResponse> {}
 export function useCwSingleProposalCountQuery({
   client,
   options
 }: CwSingleProposalCountQuery) {
   return useQuery<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>(["cwSingleProposalCount", client.contractAddress], () => client.proposalCount(), options);
 }
-export interface CwSingleReverseProposalsQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ReverseProposalsResponse, Error, ReverseProposalsResponse, (string | undefined)[]>;
+export interface CwSingleReverseProposalsQuery extends CwSingleReactQuery<ReverseProposalsResponse> {
   args: {
     limit?: number;
     startBefore?: number;
@@ -103,9 +89,7 @@ export function useCwSingleReverseProposalsQuery({
     startBefore: args.startBefore
   }), options);
 }
-export interface CwSingleListProposalsQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ListProposalsResponse, Error, ListProposalsResponse, (string | undefined)[]>;
+export interface CwSingleListProposalsQuery extends CwSingleReactQuery<ListProposalsResponse> {
   args: {
     limit?: number;
     startAfter?: number;
@@ -121,9 +105,7 @@ export function useCwSingleListProposalsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwSingleProposalQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalResponse, Error, ProposalResponse, (string | undefined)[]>;
+export interface CwSingleProposalQuery extends CwSingleReactQuery<ProposalResponse> {
   args: {
     proposalId: number;
   };
@@ -137,10 +119,7 @@ export function useCwSingleProposalQuery({
     proposalId: args.proposalId
   }), options);
 }
-export interface CwSingleConfigQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwSingleConfigQuery extends CwSingleReactQuery<ConfigResponse> {}
 export function useCwSingleConfigQuery({
   client,
   options

--- a/__output__/builder/default/Factory.react-query.ts
+++ b/__output__/builder/default/Factory.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
+export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient;
-  options?: UseQueryOptions<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
   return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client.contractAddress], () => client.adminAddr(), options);
 }
-export interface FactoryGovecAddrQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>;
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
   return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client.contractAddress], () => client.govecAddr(), options);
 }
-export interface FactoryFeeQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<FeeResponse, Error, FeeResponse, (string | undefined)[]>;
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
   return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client.contractAddress], () => client.fee(), options);
 }
-export interface FactoryCodeIdQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>;
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -53,9 +46,7 @@ export function useFactoryCodeIdQuery({
     ty: args.ty
   }), options);
 }
-export interface FactoryWalletsOfQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>;
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -73,9 +64,7 @@ export function useFactoryWalletsOfQuery({
     user: args.user
   }), options);
 }
-export interface FactoryWalletsQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>;
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/builder/default/Minter.react-query.ts
+++ b/__output__/builder/default/Minter.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, ExecuteMsg, Decimal, InstantiateMsg, InstantiateMsg1, CollectionInfoForRoyaltyInfoResponse, RoyaltyInfoResponse, QueryMsg } from "./Minter.types";
 import { MinterQueryClient } from "./Minter.client";
-export interface MinterMintCountQuery {
+export interface MinterReactQuery<TResponse> {
   client: MinterQueryClient;
-  options?: UseQueryOptions<MintCountResponse, Error, MintCountResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface MinterMintCountQuery extends MinterReactQuery<MintCountResponse> {
   args: {
     address: string;
   };
@@ -23,40 +25,28 @@ export function useMinterMintCountQuery({
     address: args.address
   }), options);
 }
-export interface MinterMintPriceQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>;
-}
+export interface MinterMintPriceQuery extends MinterReactQuery<MintPriceResponse> {}
 export function useMinterMintPriceQuery({
   client,
   options
 }: MinterMintPriceQuery) {
   return useQuery<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>(["minterMintPrice", client.contractAddress], () => client.mintPrice(), options);
 }
-export interface MinterStartTimeQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>;
-}
+export interface MinterStartTimeQuery extends MinterReactQuery<StartTimeResponse> {}
 export function useMinterStartTimeQuery({
   client,
   options
 }: MinterStartTimeQuery) {
   return useQuery<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>(["minterStartTime", client.contractAddress], () => client.startTime(), options);
 }
-export interface MinterMintableNumTokensQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>;
-}
+export interface MinterMintableNumTokensQuery extends MinterReactQuery<MintableNumTokensResponse> {}
 export function useMinterMintableNumTokensQuery({
   client,
   options
 }: MinterMintableNumTokensQuery) {
   return useQuery<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>(["minterMintableNumTokens", client.contractAddress], () => client.mintableNumTokens(), options);
 }
-export interface MinterConfigQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface MinterConfigQuery extends MinterReactQuery<ConfigResponse> {}
 export function useMinterConfigQuery({
   client,
   options

--- a/__output__/builder/invoke/CwAdminFactory.react-query.ts
+++ b/__output__/builder/invoke/CwAdminFactory.react-query.ts
@@ -4,5 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
+import { UseQueryOptions } from "react-query";
 import { ExecuteMsg, Binary, InstantiateMsg, QueryMsg } from "./CwAdminFactory.types";
 import { CwAdminFactoryQueryClient } from "./CwAdminFactory.client";
+export interface CwAdminFactoryReactQuery<TResponse> {
+  client: CwAdminFactoryQueryClient;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}

--- a/__output__/builder/invoke/CwCodeIdRegistry.react-query.ts
+++ b/__output__/builder/invoke/CwCodeIdRegistry.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, PaymentInfo, Uint128, ConfigResponse, ExecuteMsg, Binary, Cw20ReceiveMsg, GetRegistrationResponse, Registration, InfoForCodeIdResponse, InstantiateMsg, ListRegistrationsResponse, QueryMsg, ReceiveMsg } from "./CwCodeIdRegistry.types";
 import { CwCodeIdRegistryQueryClient } from "./CwCodeIdRegistry.client";
-export interface CwCodeIdRegistryListRegistrationsQuery {
+export interface CwCodeIdRegistryReactQuery<TResponse> {
   client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ListRegistrationsResponse, Error, ListRegistrationsResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface CwCodeIdRegistryListRegistrationsQuery extends CwCodeIdRegistryReactQuery<ListRegistrationsResponse> {
   args: {
     chainId: string;
     name: string;
@@ -25,9 +27,7 @@ export function useCwCodeIdRegistryListRegistrationsQuery({
     name: args.name
   }), options);
 }
-export interface CwCodeIdRegistryInfoForCodeIdQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<InfoForCodeIdResponse, Error, InfoForCodeIdResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryInfoForCodeIdQuery extends CwCodeIdRegistryReactQuery<InfoForCodeIdResponse> {
   args: {
     chainId: string;
     codeId: number;
@@ -43,9 +43,7 @@ export function useCwCodeIdRegistryInfoForCodeIdQuery({
     codeId: args.codeId
   }), options);
 }
-export interface CwCodeIdRegistryGetRegistrationQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<GetRegistrationResponse, Error, GetRegistrationResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryGetRegistrationQuery extends CwCodeIdRegistryReactQuery<GetRegistrationResponse> {
   args: {
     chainId: string;
     name: string;
@@ -63,10 +61,7 @@ export function useCwCodeIdRegistryGetRegistrationQuery({
     version: args.version
   }), options);
 }
-export interface CwCodeIdRegistryConfigQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwCodeIdRegistryConfigQuery extends CwCodeIdRegistryReactQuery<ConfigResponse> {}
 export function useCwCodeIdRegistryConfigQuery({
   client,
   options

--- a/__output__/builder/invoke/CwSingle.react-query.ts
+++ b/__output__/builder/invoke/CwSingle.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, Uint128, Duration, Threshold, PercentageThreshold, Decimal, ConfigResponse, CheckedDepositInfo, ExecuteMsg, CosmosMsgForEmpty, BankMsg, StakingMsg, DistributionMsg, Binary, IbcMsg, Timestamp, Uint64, WasmMsg, GovMsg, VoteOption, Vote, DepositToken, Coin, Empty, IbcTimeout, IbcTimeoutBlock, DepositInfo, GovernanceModulesResponse, InfoResponse, ContractVersion, InstantiateMsg, Expiration, Status, ListProposalsResponse, ProposalResponse, Proposal, Votes, ListVotesResponse, VoteInfo, MigrateMsg, ProposalCountResponse, ProposalHooksResponse, QueryMsg, ReverseProposalsResponse, VoteHooksResponse, VoteResponse } from "./CwSingle.types";
 import { CwSingleQueryClient } from "./CwSingle.client";
-export interface CwSingleInfoQuery {
+export interface CwSingleReactQuery<TResponse> {
   client: CwSingleQueryClient;
-  options?: UseQueryOptions<InfoResponse, Error, InfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface CwSingleInfoQuery extends CwSingleReactQuery<InfoResponse> {}
 export function useCwSingleInfoQuery({
   client,
   options
 }: CwSingleInfoQuery) {
   return useQuery<InfoResponse, Error, InfoResponse, (string | undefined)[]>(["cwSingleInfo", client.contractAddress], () => client.info(), options);
 }
-export interface CwSingleVoteHooksQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>;
-}
+export interface CwSingleVoteHooksQuery extends CwSingleReactQuery<VoteHooksResponse> {}
 export function useCwSingleVoteHooksQuery({
   client,
   options
 }: CwSingleVoteHooksQuery) {
   return useQuery<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>(["cwSingleVoteHooks", client.contractAddress], () => client.voteHooks(), options);
 }
-export interface CwSingleProposalHooksQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>;
-}
+export interface CwSingleProposalHooksQuery extends CwSingleReactQuery<ProposalHooksResponse> {}
 export function useCwSingleProposalHooksQuery({
   client,
   options
 }: CwSingleProposalHooksQuery) {
   return useQuery<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>(["cwSingleProposalHooks", client.contractAddress], () => client.proposalHooks(), options);
 }
-export interface CwSingleListVotesQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ListVotesResponse, Error, ListVotesResponse, (string | undefined)[]>;
+export interface CwSingleListVotesQuery extends CwSingleReactQuery<ListVotesResponse> {
   args: {
     limit?: number;
     proposalId: number;
@@ -57,9 +50,7 @@ export function useCwSingleListVotesQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwSingleVoteQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<VoteResponse, Error, VoteResponse, (string | undefined)[]>;
+export interface CwSingleVoteQuery extends CwSingleReactQuery<VoteResponse> {
   args: {
     proposalId: number;
     voter: string;
@@ -75,19 +66,14 @@ export function useCwSingleVoteQuery({
     voter: args.voter
   }), options);
 }
-export interface CwSingleProposalCountQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>;
-}
+export interface CwSingleProposalCountQuery extends CwSingleReactQuery<ProposalCountResponse> {}
 export function useCwSingleProposalCountQuery({
   client,
   options
 }: CwSingleProposalCountQuery) {
   return useQuery<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>(["cwSingleProposalCount", client.contractAddress], () => client.proposalCount(), options);
 }
-export interface CwSingleReverseProposalsQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ReverseProposalsResponse, Error, ReverseProposalsResponse, (string | undefined)[]>;
+export interface CwSingleReverseProposalsQuery extends CwSingleReactQuery<ReverseProposalsResponse> {
   args: {
     limit?: number;
     startBefore?: number;
@@ -103,9 +89,7 @@ export function useCwSingleReverseProposalsQuery({
     startBefore: args.startBefore
   }), options);
 }
-export interface CwSingleListProposalsQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ListProposalsResponse, Error, ListProposalsResponse, (string | undefined)[]>;
+export interface CwSingleListProposalsQuery extends CwSingleReactQuery<ListProposalsResponse> {
   args: {
     limit?: number;
     startAfter?: number;
@@ -121,9 +105,7 @@ export function useCwSingleListProposalsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwSingleProposalQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ProposalResponse, Error, ProposalResponse, (string | undefined)[]>;
+export interface CwSingleProposalQuery extends CwSingleReactQuery<ProposalResponse> {
   args: {
     proposalId: number;
   };
@@ -137,10 +119,7 @@ export function useCwSingleProposalQuery({
     proposalId: args.proposalId
   }), options);
 }
-export interface CwSingleConfigQuery {
-  client: CwSingleQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwSingleConfigQuery extends CwSingleReactQuery<ConfigResponse> {}
 export function useCwSingleConfigQuery({
   client,
   options

--- a/__output__/builder/invoke/Factory.react-query.ts
+++ b/__output__/builder/invoke/Factory.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
+export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient;
-  options?: UseQueryOptions<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
   return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client.contractAddress], () => client.adminAddr(), options);
 }
-export interface FactoryGovecAddrQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>;
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
   return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client.contractAddress], () => client.govecAddr(), options);
 }
-export interface FactoryFeeQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<FeeResponse, Error, FeeResponse, (string | undefined)[]>;
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
   return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client.contractAddress], () => client.fee(), options);
 }
-export interface FactoryCodeIdQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>;
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -53,9 +46,7 @@ export function useFactoryCodeIdQuery({
     ty: args.ty
   }), options);
 }
-export interface FactoryWalletsOfQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>;
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -73,9 +64,7 @@ export function useFactoryWalletsOfQuery({
     user: args.user
   }), options);
 }
-export interface FactoryWalletsQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>;
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/builder/invoke/Minter.react-query.ts
+++ b/__output__/builder/invoke/Minter.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, ExecuteMsg, Decimal, InstantiateMsg, InstantiateMsg1, CollectionInfoForRoyaltyInfoResponse, RoyaltyInfoResponse, QueryMsg } from "./Minter.types";
 import { MinterQueryClient } from "./Minter.client";
-export interface MinterMintCountQuery {
+export interface MinterReactQuery<TResponse> {
   client: MinterQueryClient;
-  options?: UseQueryOptions<MintCountResponse, Error, MintCountResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface MinterMintCountQuery extends MinterReactQuery<MintCountResponse> {
   args: {
     address: string;
   };
@@ -23,40 +25,28 @@ export function useMinterMintCountQuery({
     address: args.address
   }), options);
 }
-export interface MinterMintPriceQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>;
-}
+export interface MinterMintPriceQuery extends MinterReactQuery<MintPriceResponse> {}
 export function useMinterMintPriceQuery({
   client,
   options
 }: MinterMintPriceQuery) {
   return useQuery<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>(["minterMintPrice", client.contractAddress], () => client.mintPrice(), options);
 }
-export interface MinterStartTimeQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>;
-}
+export interface MinterStartTimeQuery extends MinterReactQuery<StartTimeResponse> {}
 export function useMinterStartTimeQuery({
   client,
   options
 }: MinterStartTimeQuery) {
   return useQuery<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>(["minterStartTime", client.contractAddress], () => client.startTime(), options);
 }
-export interface MinterMintableNumTokensQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>;
-}
+export interface MinterMintableNumTokensQuery extends MinterReactQuery<MintableNumTokensResponse> {}
 export function useMinterMintableNumTokensQuery({
   client,
   options
 }: MinterMintableNumTokensQuery) {
   return useQuery<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>(["minterMintableNumTokens", client.contractAddress], () => client.mintableNumTokens(), options);
 }
-export interface MinterConfigQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface MinterConfigQuery extends MinterReactQuery<ConfigResponse> {}
 export function useMinterConfigQuery({
   client,
   options

--- a/__output__/cosmwasm/CW4Group.react-query.ts
+++ b/__output__/cosmwasm/CW4Group.react-query.ts
@@ -7,19 +7,18 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { InstantiateMsg, Member, ExecuteMsg, QueryMsg, QueryResponse, AdminResponse, TotalWeightResponse, MemberListResponse, MemberResponse, HooksResponse } from "./CW4Group.types";
 import { CW4GroupQueryClient } from "./CW4Group.client";
-export interface CW4GroupHooksQuery {
+export interface CW4GroupReactQuery<TResponse> {
   client: CW4GroupQueryClient;
-  options?: UseQueryOptions<HooksResponse, Error, HooksResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface CW4GroupHooksQuery extends CW4GroupReactQuery<HooksResponse> {}
 export function useCW4GroupHooksQuery({
   client,
   options
 }: CW4GroupHooksQuery) {
   return useQuery<HooksResponse, Error, HooksResponse, (string | undefined)[]>(["cW4GroupHooks", client.contractAddress], () => client.hooks(), options);
 }
-export interface CW4GroupMemberQuery {
-  client: CW4GroupQueryClient;
-  options?: UseQueryOptions<MemberResponse, Error, MemberResponse, (string | undefined)[]>;
+export interface CW4GroupMemberQuery extends CW4GroupReactQuery<MemberResponse> {
   args: {
     addr: string;
     atHeight?: number;
@@ -35,9 +34,7 @@ export function useCW4GroupMemberQuery({
     atHeight: args.atHeight
   }), options);
 }
-export interface CW4GroupListMembersQuery {
-  client: CW4GroupQueryClient;
-  options?: UseQueryOptions<ListMembersResponse, Error, ListMembersResponse, (string | undefined)[]>;
+export interface CW4GroupListMembersQuery extends CW4GroupReactQuery<ListMembersResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -53,20 +50,14 @@ export function useCW4GroupListMembersQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CW4GroupTotalWeightQuery {
-  client: CW4GroupQueryClient;
-  options?: UseQueryOptions<TotalWeightResponse, Error, TotalWeightResponse, (string | undefined)[]>;
-}
+export interface CW4GroupTotalWeightQuery extends CW4GroupReactQuery<TotalWeightResponse> {}
 export function useCW4GroupTotalWeightQuery({
   client,
   options
 }: CW4GroupTotalWeightQuery) {
   return useQuery<TotalWeightResponse, Error, TotalWeightResponse, (string | undefined)[]>(["cW4GroupTotalWeight", client.contractAddress], () => client.totalWeight(), options);
 }
-export interface CW4GroupAdminQuery {
-  client: CW4GroupQueryClient;
-  options?: UseQueryOptions<AdminResponse, Error, AdminResponse, (string | undefined)[]>;
-}
+export interface CW4GroupAdminQuery extends CW4GroupReactQuery<AdminResponse> {}
 export function useCW4GroupAdminQuery({
   client,
   options

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.react-query.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.react-query.ts
@@ -4,5 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
+import { UseQueryOptions } from "react-query";
 import { ExecuteMsg, Binary, InstantiateMsg, QueryMsg } from "./CwAdminFactory.types";
 import { CwAdminFactoryQueryClient } from "./CwAdminFactory.client";
+export interface CwAdminFactoryReactQuery<TResponse> {
+  client: CwAdminFactoryQueryClient;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.react-query.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, PaymentInfo, Uint128, ConfigResponse, ExecuteMsg, Binary, Cw20ReceiveMsg, GetRegistrationResponse, Registration, InfoForCodeIdResponse, InstantiateMsg, ListRegistrationsResponse, QueryMsg, ReceiveMsg } from "./CwCodeIdRegistry.types";
 import { CwCodeIdRegistryQueryClient } from "./CwCodeIdRegistry.client";
-export interface CwCodeIdRegistryListRegistrationsQuery {
+export interface CwCodeIdRegistryReactQuery<TResponse> {
   client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ListRegistrationsResponse, Error, ListRegistrationsResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface CwCodeIdRegistryListRegistrationsQuery extends CwCodeIdRegistryReactQuery<ListRegistrationsResponse> {
   args: {
     chainId: string;
     name: string;
@@ -25,9 +27,7 @@ export function useCwCodeIdRegistryListRegistrationsQuery({
     name: args.name
   }), options);
 }
-export interface CwCodeIdRegistryInfoForCodeIdQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<InfoForCodeIdResponse, Error, InfoForCodeIdResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryInfoForCodeIdQuery extends CwCodeIdRegistryReactQuery<InfoForCodeIdResponse> {
   args: {
     chainId: string;
     codeId: number;
@@ -43,9 +43,7 @@ export function useCwCodeIdRegistryInfoForCodeIdQuery({
     codeId: args.codeId
   }), options);
 }
-export interface CwCodeIdRegistryGetRegistrationQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<GetRegistrationResponse, Error, GetRegistrationResponse, (string | undefined)[]>;
+export interface CwCodeIdRegistryGetRegistrationQuery extends CwCodeIdRegistryReactQuery<GetRegistrationResponse> {
   args: {
     chainId: string;
     name: string;
@@ -63,10 +61,7 @@ export function useCwCodeIdRegistryGetRegistrationQuery({
     version: args.version
   }), options);
 }
-export interface CwCodeIdRegistryConfigQuery {
-  client: CwCodeIdRegistryQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwCodeIdRegistryConfigQuery extends CwCodeIdRegistryReactQuery<ConfigResponse> {}
 export function useCwCodeIdRegistryConfigQuery({
   client,
   options

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.react-query.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { DumpResponse, Group, ExecuteMsg, InstantiateMsg, Addr, ListAddressesResponse, ListGroupsResponse, QueryMsg } from "./CwNamedGroups.types";
 import { CwNamedGroupsQueryClient } from "./CwNamedGroups.client";
-export interface CwNamedGroupsIsAddressInGroupQuery {
+export interface CwNamedGroupsReactQuery<TResponse> {
   client: CwNamedGroupsQueryClient;
-  options?: UseQueryOptions<IsAddressInGroupResponse, Error, IsAddressInGroupResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface CwNamedGroupsIsAddressInGroupQuery extends CwNamedGroupsReactQuery<IsAddressInGroupResponse> {
   args: {
     address: string;
     group: string;
@@ -25,9 +27,7 @@ export function useCwNamedGroupsIsAddressInGroupQuery({
     group: args.group
   }), options);
 }
-export interface CwNamedGroupsListAddressesQuery {
-  client: CwNamedGroupsQueryClient;
-  options?: UseQueryOptions<ListAddressesResponse, Error, ListAddressesResponse, (string | undefined)[]>;
+export interface CwNamedGroupsListAddressesQuery extends CwNamedGroupsReactQuery<ListAddressesResponse> {
   args: {
     group: string;
     limit?: number;
@@ -45,9 +45,7 @@ export function useCwNamedGroupsListAddressesQuery({
     offset: args.offset
   }), options);
 }
-export interface CwNamedGroupsListGroupsQuery {
-  client: CwNamedGroupsQueryClient;
-  options?: UseQueryOptions<ListGroupsResponse, Error, ListGroupsResponse, (string | undefined)[]>;
+export interface CwNamedGroupsListGroupsQuery extends CwNamedGroupsReactQuery<ListGroupsResponse> {
   args: {
     address: string;
     limit?: number;
@@ -65,10 +63,7 @@ export function useCwNamedGroupsListGroupsQuery({
     offset: args.offset
   }), options);
 }
-export interface CwNamedGroupsDumpQuery {
-  client: CwNamedGroupsQueryClient;
-  options?: UseQueryOptions<DumpResponse, Error, DumpResponse, (string | undefined)[]>;
-}
+export interface CwNamedGroupsDumpQuery extends CwNamedGroupsReactQuery<DumpResponse> {}
 export function useCwNamedGroupsDumpQuery({
   client,
   options

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.react-query.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Addr, Uint128, Duration, Threshold, PercentageThreshold, Decimal, ConfigResponse, CheckedDepositInfo, ExecuteMsg, CosmosMsgForEmpty, BankMsg, StakingMsg, DistributionMsg, Binary, IbcMsg, Timestamp, Uint64, WasmMsg, GovMsg, VoteOption, Vote, DepositToken, Coin, Empty, IbcTimeout, IbcTimeoutBlock, DepositInfo, GovernanceModulesResponse, InfoResponse, ContractVersion, InstantiateMsg, Expiration, Status, ListProposalsResponse, ProposalResponse, Proposal, Votes, ListVotesResponse, VoteInfo, MigrateMsg, ProposalCountResponse, ProposalHooksResponse, QueryMsg, ReverseProposalsResponse, VoteHooksResponse, VoteResponse } from "./CwProposalSingle.types";
 import { CwProposalSingleQueryClient } from "./CwProposalSingle.client";
-export interface CwProposalSingleInfoQuery {
+export interface CwProposalSingleReactQuery<TResponse> {
   client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<InfoResponse, Error, InfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface CwProposalSingleInfoQuery extends CwProposalSingleReactQuery<InfoResponse> {}
 export function useCwProposalSingleInfoQuery({
   client,
   options
 }: CwProposalSingleInfoQuery) {
   return useQuery<InfoResponse, Error, InfoResponse, (string | undefined)[]>(["cwProposalSingleInfo", client.contractAddress], () => client.info(), options);
 }
-export interface CwProposalSingleVoteHooksQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>;
-}
+export interface CwProposalSingleVoteHooksQuery extends CwProposalSingleReactQuery<VoteHooksResponse> {}
 export function useCwProposalSingleVoteHooksQuery({
   client,
   options
 }: CwProposalSingleVoteHooksQuery) {
   return useQuery<VoteHooksResponse, Error, VoteHooksResponse, (string | undefined)[]>(["cwProposalSingleVoteHooks", client.contractAddress], () => client.voteHooks(), options);
 }
-export interface CwProposalSingleProposalHooksQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>;
-}
+export interface CwProposalSingleProposalHooksQuery extends CwProposalSingleReactQuery<ProposalHooksResponse> {}
 export function useCwProposalSingleProposalHooksQuery({
   client,
   options
 }: CwProposalSingleProposalHooksQuery) {
   return useQuery<ProposalHooksResponse, Error, ProposalHooksResponse, (string | undefined)[]>(["cwProposalSingleProposalHooks", client.contractAddress], () => client.proposalHooks(), options);
 }
-export interface CwProposalSingleListVotesQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ListVotesResponse, Error, ListVotesResponse, (string | undefined)[]>;
+export interface CwProposalSingleListVotesQuery extends CwProposalSingleReactQuery<ListVotesResponse> {
   args: {
     limit?: number;
     proposalId: number;
@@ -57,9 +50,7 @@ export function useCwProposalSingleListVotesQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwProposalSingleVoteQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<VoteResponse, Error, VoteResponse, (string | undefined)[]>;
+export interface CwProposalSingleVoteQuery extends CwProposalSingleReactQuery<VoteResponse> {
   args: {
     proposalId: number;
     voter: string;
@@ -75,19 +66,14 @@ export function useCwProposalSingleVoteQuery({
     voter: args.voter
   }), options);
 }
-export interface CwProposalSingleProposalCountQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>;
-}
+export interface CwProposalSingleProposalCountQuery extends CwProposalSingleReactQuery<ProposalCountResponse> {}
 export function useCwProposalSingleProposalCountQuery({
   client,
   options
 }: CwProposalSingleProposalCountQuery) {
   return useQuery<ProposalCountResponse, Error, ProposalCountResponse, (string | undefined)[]>(["cwProposalSingleProposalCount", client.contractAddress], () => client.proposalCount(), options);
 }
-export interface CwProposalSingleReverseProposalsQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ReverseProposalsResponse, Error, ReverseProposalsResponse, (string | undefined)[]>;
+export interface CwProposalSingleReverseProposalsQuery extends CwProposalSingleReactQuery<ReverseProposalsResponse> {
   args: {
     limit?: number;
     startBefore?: number;
@@ -103,9 +89,7 @@ export function useCwProposalSingleReverseProposalsQuery({
     startBefore: args.startBefore
   }), options);
 }
-export interface CwProposalSingleListProposalsQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ListProposalsResponse, Error, ListProposalsResponse, (string | undefined)[]>;
+export interface CwProposalSingleListProposalsQuery extends CwProposalSingleReactQuery<ListProposalsResponse> {
   args: {
     limit?: number;
     startAfter?: number;
@@ -121,9 +105,7 @@ export function useCwProposalSingleListProposalsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface CwProposalSingleProposalQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ProposalResponse, Error, ProposalResponse, (string | undefined)[]>;
+export interface CwProposalSingleProposalQuery extends CwProposalSingleReactQuery<ProposalResponse> {
   args: {
     proposalId: number;
   };
@@ -137,10 +119,7 @@ export function useCwProposalSingleProposalQuery({
     proposalId: args.proposalId
   }), options);
 }
-export interface CwProposalSingleConfigQuery {
-  client: CwProposalSingleQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface CwProposalSingleConfigQuery extends CwProposalSingleReactQuery<ConfigResponse> {}
 export function useCwProposalSingleConfigQuery({
   client,
   options

--- a/__output__/minter/Minter.react-query.ts
+++ b/__output__/minter/Minter.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, ExecuteMsg, Decimal, InstantiateMsg, InstantiateMsg1, CollectionInfoForRoyaltyInfoResponse, RoyaltyInfoResponse, QueryMsg } from "./Minter.types";
 import { MinterQueryClient } from "./Minter.client";
-export interface MinterMintCountQuery {
+export interface MinterReactQuery<TResponse> {
   client: MinterQueryClient;
-  options?: UseQueryOptions<MintCountResponse, Error, MintCountResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface MinterMintCountQuery extends MinterReactQuery<MintCountResponse> {
   args: {
     address: string;
   };
@@ -23,40 +25,28 @@ export function useMinterMintCountQuery({
     address: args.address
   }), options);
 }
-export interface MinterMintPriceQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>;
-}
+export interface MinterMintPriceQuery extends MinterReactQuery<MintPriceResponse> {}
 export function useMinterMintPriceQuery({
   client,
   options
 }: MinterMintPriceQuery) {
   return useQuery<MintPriceResponse, Error, MintPriceResponse, (string | undefined)[]>(["minterMintPrice", client.contractAddress], () => client.mintPrice(), options);
 }
-export interface MinterStartTimeQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>;
-}
+export interface MinterStartTimeQuery extends MinterReactQuery<StartTimeResponse> {}
 export function useMinterStartTimeQuery({
   client,
   options
 }: MinterStartTimeQuery) {
   return useQuery<StartTimeResponse, Error, StartTimeResponse, (string | undefined)[]>(["minterStartTime", client.contractAddress], () => client.startTime(), options);
 }
-export interface MinterMintableNumTokensQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>;
-}
+export interface MinterMintableNumTokensQuery extends MinterReactQuery<MintableNumTokensResponse> {}
 export function useMinterMintableNumTokensQuery({
   client,
   options
 }: MinterMintableNumTokensQuery) {
   return useQuery<MintableNumTokensResponse, Error, MintableNumTokensResponse, (string | undefined)[]>(["minterMintableNumTokens", client.contractAddress], () => client.mintableNumTokens(), options);
 }
-export interface MinterConfigQuery {
-  client: MinterQueryClient;
-  options?: UseQueryOptions<ConfigResponse, Error, ConfigResponse, (string | undefined)[]>;
-}
+export interface MinterConfigQuery extends MinterReactQuery<ConfigResponse> {}
 export function useMinterConfigQuery({
   client,
   options

--- a/__output__/sg721/Sg721.react-query.ts
+++ b/__output__/sg721/Sg721.react-query.ts
@@ -7,29 +7,25 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { Expiration, Timestamp, Uint64, AllNftInfoResponse, OwnerOfResponse, Approval, NftInfoResponseForEmpty, Empty, AllOperatorsResponse, AllTokensResponse, ApprovalResponse, ApprovalsResponse, Decimal, CollectionInfoResponse, RoyaltyInfoResponse, ContractInfoResponse, ExecuteMsgForEmpty, Binary, MintMsgForEmpty, InstantiateMsg, CollectionInfoForRoyaltyInfoResponse, MinterResponse, NftInfoResponse, NumTokensResponse, OperatorsResponse, QueryMsg, TokensResponse } from "./Sg721.types";
 import { Sg721QueryClient } from "./Sg721.client";
-export interface Sg721CollectionInfoQuery {
+export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient;
-  options?: UseQueryOptions<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
 }: Sg721CollectionInfoQuery) {
   return useQuery<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>(["sg721CollectionInfo", client.contractAddress], () => client.collectionInfo(), options);
 }
-export interface Sg721MinterQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<MinterResponse, Error, MinterResponse, (string | undefined)[]>;
-}
+export interface Sg721MinterQuery extends Sg721ReactQuery<MinterResponse> {}
 export function useSg721MinterQuery({
   client,
   options
 }: Sg721MinterQuery) {
   return useQuery<MinterResponse, Error, MinterResponse, (string | undefined)[]>(["sg721Minter", client.contractAddress], () => client.minter(), options);
 }
-export interface Sg721AllTokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllTokensResponse, Error, AllTokensResponse, (string | undefined)[]>;
+export interface Sg721AllTokensQuery extends Sg721ReactQuery<AllTokensResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -45,9 +41,7 @@ export function useSg721AllTokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721TokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<TokensResponse, Error, TokensResponse, (string | undefined)[]>;
+export interface Sg721TokensQuery extends Sg721ReactQuery<TokensResponse> {
   args: {
     limit?: number;
     owner: string;
@@ -65,9 +59,7 @@ export function useSg721TokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721AllNftInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllNftInfoResponse, Error, AllNftInfoResponse, (string | undefined)[]>;
+export interface Sg721AllNftInfoQuery extends Sg721ReactQuery<AllNftInfoResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -83,9 +75,7 @@ export function useSg721AllNftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721NftInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<NftInfoResponse, Error, NftInfoResponse, (string | undefined)[]>;
+export interface Sg721NftInfoQuery extends Sg721ReactQuery<NftInfoResponse> {
   args: {
     tokenId: string;
   };
@@ -99,29 +89,21 @@ export function useSg721NftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ContractInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>;
-}
+export interface Sg721ContractInfoQuery extends Sg721ReactQuery<ContractInfoResponse> {}
 export function useSg721ContractInfoQuery({
   client,
   options
 }: Sg721ContractInfoQuery) {
   return useQuery<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>(["sg721ContractInfo", client.contractAddress], () => client.contractInfo(), options);
 }
-export interface Sg721NumTokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>;
-}
+export interface Sg721NumTokensQuery extends Sg721ReactQuery<NumTokensResponse> {}
 export function useSg721NumTokensQuery({
   client,
   options
 }: Sg721NumTokensQuery) {
   return useQuery<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>(["sg721NumTokens", client.contractAddress], () => client.numTokens(), options);
 }
-export interface Sg721AllOperatorsQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllOperatorsResponse, Error, AllOperatorsResponse, (string | undefined)[]>;
+export interface Sg721AllOperatorsQuery extends Sg721ReactQuery<AllOperatorsResponse> {
   args: {
     includeExpired?: boolean;
     limit?: number;
@@ -141,9 +123,7 @@ export function useSg721AllOperatorsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721ApprovalsQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ApprovalsResponse, Error, ApprovalsResponse, (string | undefined)[]>;
+export interface Sg721ApprovalsQuery extends Sg721ReactQuery<ApprovalsResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -159,9 +139,7 @@ export function useSg721ApprovalsQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ApprovalQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ApprovalResponse, Error, ApprovalResponse, (string | undefined)[]>;
+export interface Sg721ApprovalQuery extends Sg721ReactQuery<ApprovalResponse> {
   args: {
     includeExpired?: boolean;
     spender: string;
@@ -179,9 +157,7 @@ export function useSg721ApprovalQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721OwnerOfQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<OwnerOfResponse, Error, OwnerOfResponse, (string | undefined)[]>;
+export interface Sg721OwnerOfQuery extends Sg721ReactQuery<OwnerOfResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;

--- a/__output__/vectis/factory-optional-client/Factory.react-query.ts
+++ b/__output__/vectis/factory-optional-client/Factory.react-query.ts
@@ -9,14 +9,14 @@ import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateW
 import { FactoryQueryClient } from "./Factory.client";
 export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient | undefined;
-  options?: UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
 export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
-  return useQuery<AdminAddrResponse | undefined, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client?.contractAddress], () => client ? client.adminAddr() : undefined, { ...options,
+  return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client?.contractAddress], () => client ? client.adminAddr() : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -25,7 +25,7 @@ export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
-  return useQuery<GovecAddrResponse | undefined, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client?.contractAddress], () => client ? client.govecAddr() : undefined, { ...options,
+  return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client?.contractAddress], () => client ? client.govecAddr() : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -34,7 +34,7 @@ export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
-  return useQuery<FeeResponse | undefined, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client?.contractAddress], () => client ? client.fee() : undefined, { ...options,
+  return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client?.contractAddress], () => client ? client.fee() : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -48,9 +48,9 @@ export function useFactoryCodeIdQuery({
   args,
   options
 }: FactoryCodeIdQuery) {
-  return useQuery<CodeIdResponse | undefined, Error, CodeIdResponse, (string | undefined)[]>(["factoryCodeId", client?.contractAddress, JSON.stringify(args)], () => client ? client.codeId({
+  return useQuery<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>(["factoryCodeId", client?.contractAddress, JSON.stringify(args)], () => client ? client.codeId({
     ty: args.ty
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -66,11 +66,11 @@ export function useFactoryWalletsOfQuery({
   args,
   options
 }: FactoryWalletsOfQuery) {
-  return useQuery<WalletsOfResponse | undefined, Error, WalletsOfResponse, (string | undefined)[]>(["factoryWalletsOf", client?.contractAddress, JSON.stringify(args)], () => client ? client.walletsOf({
+  return useQuery<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>(["factoryWalletsOf", client?.contractAddress, JSON.stringify(args)], () => client ? client.walletsOf({
     limit: args.limit,
     startAfter: args.startAfter,
     user: args.user
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -85,10 +85,10 @@ export function useFactoryWalletsQuery({
   args,
   options
 }: FactoryWalletsQuery) {
-  return useQuery<WalletsResponse | undefined, Error, WalletsResponse, (string | undefined)[]>(["factoryWallets", client?.contractAddress, JSON.stringify(args)], () => client ? client.wallets({
+  return useQuery<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>(["factoryWallets", client?.contractAddress, JSON.stringify(args)], () => client ? client.wallets({
     limit: args.limit,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error("Invalid client")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }

--- a/__output__/vectis/factory-optional-client/Factory.react-query.ts
+++ b/__output__/vectis/factory-optional-client/Factory.react-query.ts
@@ -7,10 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<AdminAddrResponse | undefined, Error, AdminAddrResponse, (string | undefined)[]>;
+export interface FactoryReactQuery<TResponse> {
+  client: FactoryQueryClient | undefined;
+  options?: UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>;
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
@@ -19,10 +20,7 @@ export function useFactoryAdminAddrQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface FactoryGovecAddrQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<GovecAddrResponse | undefined, Error, GovecAddrResponse, (string | undefined)[]>;
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
@@ -31,10 +29,7 @@ export function useFactoryGovecAddrQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface FactoryFeeQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<FeeResponse | undefined, Error, FeeResponse, (string | undefined)[]>;
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
@@ -43,9 +38,7 @@ export function useFactoryFeeQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface FactoryCodeIdQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<CodeIdResponse | undefined, Error, CodeIdResponse, (string | undefined)[]>;
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -61,9 +54,7 @@ export function useFactoryCodeIdQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface FactoryWalletsOfQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsOfResponse | undefined, Error, WalletsOfResponse, (string | undefined)[]>;
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -83,9 +74,7 @@ export function useFactoryWalletsOfQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface FactoryWalletsQuery {
-  client?: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsResponse | undefined, Error, WalletsResponse, (string | undefined)[]>;
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/vectis/factory-v4-query/Factory.react-query.ts
+++ b/__output__/vectis/factory-v4-query/Factory.react-query.ts
@@ -7,47 +7,34 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
+export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
+  options?: Omit<UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
     initialData?: undefined;
   };
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
   return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client.contractAddress], () => client.adminAddr(), options);
 }
-export interface FactoryGovecAddrQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
   return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client.contractAddress], () => client.govecAddr(), options);
 }
-export interface FactoryFeeQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<FeeResponse, Error, FeeResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
   return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client.contractAddress], () => client.fee(), options);
 }
-export interface FactoryCodeIdQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -61,11 +48,7 @@ export function useFactoryCodeIdQuery({
     ty: args.ty
   }), options);
 }
-export interface FactoryWalletsOfQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -83,11 +66,7 @@ export function useFactoryWalletsOfQuery({
     user: args.user
   }), options);
 }
-export interface FactoryWalletsQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/vectis/factory-w-mutations/Factory.react-query.ts
+++ b/__output__/vectis/factory-w-mutations/Factory.react-query.ts
@@ -8,47 +8,34 @@ import { UseQueryOptions, useQuery, useMutation, UseMutationOptions } from "@tan
 import { ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient, FactoryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
+export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
+  options?: Omit<UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
     initialData?: undefined;
   };
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
   return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client.contractAddress], () => client.adminAddr(), options);
 }
-export interface FactoryGovecAddrQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
   return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client.contractAddress], () => client.govecAddr(), options);
 }
-export interface FactoryFeeQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<FeeResponse, Error, FeeResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
   return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client.contractAddress], () => client.fee(), options);
 }
-export interface FactoryCodeIdQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -62,11 +49,7 @@ export function useFactoryCodeIdQuery({
     ty: args.ty
   }), options);
 }
-export interface FactoryWalletsOfQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -84,11 +67,7 @@ export function useFactoryWalletsOfQuery({
     user: args.user
   }), options);
 }
-export interface FactoryWalletsQuery {
-  client: FactoryQueryClient;
-  options?: Omit<UseQueryOptions<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>, "'queryKey' | 'queryFn' | 'initialData'"> & {
-    initialData?: undefined;
-  };
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/vectis/factory-w-mutations/Factory.react-query.ts
+++ b/__output__/vectis/factory-w-mutations/Factory.react-query.ts
@@ -6,6 +6,7 @@
 
 import { UseQueryOptions, useQuery, useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { ExecuteResult } from "@cosmjs/cosmwasm-stargate";
+import { StdFee } from "@cosmjs/amino";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient, FactoryClient } from "./Factory.client";
 export interface FactoryReactQuery<TResponse> {

--- a/__output__/vectis/factory/Factory.react-query.ts
+++ b/__output__/vectis/factory/Factory.react-query.ts
@@ -7,39 +7,32 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient } from "./Factory.client";
-export interface FactoryAdminAddrQuery {
+export interface FactoryReactQuery<TResponse> {
   client: FactoryQueryClient;
-  options?: UseQueryOptions<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface FactoryAdminAddrQuery extends FactoryReactQuery<AdminAddrResponse> {}
 export function useFactoryAdminAddrQuery({
   client,
   options
 }: FactoryAdminAddrQuery) {
   return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client.contractAddress], () => client.adminAddr(), options);
 }
-export interface FactoryGovecAddrQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>;
-}
+export interface FactoryGovecAddrQuery extends FactoryReactQuery<GovecAddrResponse> {}
 export function useFactoryGovecAddrQuery({
   client,
   options
 }: FactoryGovecAddrQuery) {
   return useQuery<GovecAddrResponse, Error, GovecAddrResponse, (string | undefined)[]>(["factoryGovecAddr", client.contractAddress], () => client.govecAddr(), options);
 }
-export interface FactoryFeeQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<FeeResponse, Error, FeeResponse, (string | undefined)[]>;
-}
+export interface FactoryFeeQuery extends FactoryReactQuery<FeeResponse> {}
 export function useFactoryFeeQuery({
   client,
   options
 }: FactoryFeeQuery) {
   return useQuery<FeeResponse, Error, FeeResponse, (string | undefined)[]>(["factoryFee", client.contractAddress], () => client.fee(), options);
 }
-export interface FactoryCodeIdQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<CodeIdResponse, Error, CodeIdResponse, (string | undefined)[]>;
+export interface FactoryCodeIdQuery extends FactoryReactQuery<CodeIdResponse> {
   args: {
     ty: CodeIdType;
   };
@@ -53,9 +46,7 @@ export function useFactoryCodeIdQuery({
     ty: args.ty
   }), options);
 }
-export interface FactoryWalletsOfQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsOfResponse, Error, WalletsOfResponse, (string | undefined)[]>;
+export interface FactoryWalletsOfQuery extends FactoryReactQuery<WalletsOfResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -73,9 +64,7 @@ export function useFactoryWalletsOfQuery({
     user: args.user
   }), options);
 }
-export interface FactoryWalletsQuery {
-  client: FactoryQueryClient;
-  options?: UseQueryOptions<WalletsResponse, Error, WalletsResponse, (string | undefined)[]>;
+export interface FactoryWalletsQuery extends FactoryReactQuery<WalletsResponse> {
   args: {
     limit?: number;
     startAfter?: WalletQueryPrefix;

--- a/__output__/vectis/govec/Govec.react-query.ts
+++ b/__output__/vectis/govec/Govec.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { CanExecuteRelayResponse, CosmosMsgForEmpty, BankMsg, Uint128, StakingMsg, DistributionMsg, WasmMsg, Binary, Coin, Empty, ExecuteMsgForEmpty, Addr, RelayTransaction, Guardians, MultiSig, InfoResponse, ContractVersion, InstantiateMsg, CreateWalletMsg, QueryMsg, Uint64 } from "./Govec.types";
 import { GovecQueryClient } from "./Govec.client";
-export interface GovecCanExecuteRelayQuery {
+export interface GovecReactQuery<TResponse> {
   client: GovecQueryClient;
-  options?: UseQueryOptions<CanExecuteRelayResponse, Error, CanExecuteRelayResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface GovecCanExecuteRelayQuery extends GovecReactQuery<CanExecuteRelayResponse> {
   args: {
     sender: string;
   };
@@ -23,10 +25,7 @@ export function useGovecCanExecuteRelayQuery({
     sender: args.sender
   }), options);
 }
-export interface GovecInfoQuery {
-  client: GovecQueryClient;
-  options?: UseQueryOptions<InfoResponse, Error, InfoResponse, (string | undefined)[]>;
-}
+export interface GovecInfoQuery extends GovecReactQuery<InfoResponse> {}
 export function useGovecInfoQuery({
   client,
   options

--- a/__output__/vectis/proxy/Proxy.react-query.ts
+++ b/__output__/vectis/proxy/Proxy.react-query.ts
@@ -7,9 +7,11 @@
 import { UseQueryOptions, useQuery } from "react-query";
 import { CanExecuteRelayResponse, CosmosMsgForEmpty, BankMsg, Uint128, StakingMsg, DistributionMsg, WasmMsg, Binary, Coin, Empty, ExecuteMsgForEmpty, Addr, RelayTransaction, Guardians, MultiSig, InfoResponse, ContractVersion, InstantiateMsg, CreateWalletMsg, QueryMsg, Uint64 } from "./Proxy.types";
 import { ProxyQueryClient } from "./Proxy.client";
-export interface ProxyCanExecuteRelayQuery {
+export interface ProxyReactQuery<TResponse> {
   client: ProxyQueryClient;
-  options?: UseQueryOptions<CanExecuteRelayResponse, Error, CanExecuteRelayResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
+}
+export interface ProxyCanExecuteRelayQuery extends ProxyReactQuery<CanExecuteRelayResponse> {
   args: {
     sender: string;
   };
@@ -23,10 +25,7 @@ export function useProxyCanExecuteRelayQuery({
     sender: args.sender
   }), options);
 }
-export interface ProxyInfoQuery {
-  client: ProxyQueryClient;
-  options?: UseQueryOptions<InfoResponse, Error, InfoResponse, (string | undefined)[]>;
-}
+export interface ProxyInfoQuery extends ProxyReactQuery<InfoResponse> {}
 export function useProxyInfoQuery({
   client,
   options

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -195,7 +195,7 @@ export function useSg721OwnerOfQuery({
 
 exports[`createReactQueryHooks 2`] = `
 "export interface Sg721CollectionInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>;
 }
 export function useSg721CollectionInfoQuery({
@@ -207,7 +207,7 @@ export function useSg721CollectionInfoQuery({
   });
 }
 export interface Sg721MinterQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>;
 }
 export function useSg721MinterQuery({
@@ -219,7 +219,7 @@ export function useSg721MinterQuery({
   });
 }
 export interface Sg721AllTokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>;
   args: {
     limit?: number;
@@ -239,7 +239,7 @@ export function useSg721AllTokensQuery({
   });
 }
 export interface Sg721TokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>;
   args: {
     limit?: number;
@@ -261,7 +261,7 @@ export function useSg721TokensQuery({
   });
 }
 export interface Sg721AllNftInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>;
   args: {
     includeExpired?: boolean;
@@ -281,7 +281,7 @@ export function useSg721AllNftInfoQuery({
   });
 }
 export interface Sg721NftInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>;
   args: {
     tokenId: string;
@@ -299,7 +299,7 @@ export function useSg721NftInfoQuery({
   });
 }
 export interface Sg721ContractInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>;
 }
 export function useSg721ContractInfoQuery({
@@ -311,7 +311,7 @@ export function useSg721ContractInfoQuery({
   });
 }
 export interface Sg721NumTokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>;
 }
 export function useSg721NumTokensQuery({
@@ -323,7 +323,7 @@ export function useSg721NumTokensQuery({
   });
 }
 export interface Sg721AllOperatorsQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>;
   args: {
     includeExpired?: boolean;
@@ -347,7 +347,7 @@ export function useSg721AllOperatorsQuery({
   });
 }
 export interface Sg721ApprovalsQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>;
   args: {
     includeExpired?: boolean;
@@ -367,7 +367,7 @@ export function useSg721ApprovalsQuery({
   });
 }
 export interface Sg721ApprovalQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>;
   args: {
     includeExpired?: boolean;
@@ -389,7 +389,7 @@ export function useSg721ApprovalQuery({
   });
 }
 export interface Sg721OwnerOfQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: UseQueryOptions<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>;
   args: {
     includeExpired?: boolean;
@@ -629,7 +629,7 @@ export function useSg721OwnerOfQuery({
 
 exports[`createReactQueryHooks 4`] = `
 "export interface Sg721CollectionInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -643,7 +643,7 @@ export function useSg721CollectionInfoQuery({
   });
 }
 export interface Sg721MinterQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -657,7 +657,7 @@ export function useSg721MinterQuery({
   });
 }
 export interface Sg721AllTokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -679,7 +679,7 @@ export function useSg721AllTokensQuery({
   });
 }
 export interface Sg721TokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -703,7 +703,7 @@ export function useSg721TokensQuery({
   });
 }
 export interface Sg721AllNftInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -725,7 +725,7 @@ export function useSg721AllNftInfoQuery({
   });
 }
 export interface Sg721NftInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -745,7 +745,7 @@ export function useSg721NftInfoQuery({
   });
 }
 export interface Sg721ContractInfoQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -759,7 +759,7 @@ export function useSg721ContractInfoQuery({
   });
 }
 export interface Sg721NumTokensQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -773,7 +773,7 @@ export function useSg721NumTokensQuery({
   });
 }
 export interface Sg721AllOperatorsQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -799,7 +799,7 @@ export function useSg721AllOperatorsQuery({
   });
 }
 export interface Sg721ApprovalsQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -821,7 +821,7 @@ export function useSg721ApprovalsQuery({
   });
 }
 export interface Sg721ApprovalQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
@@ -845,7 +845,7 @@ export function useSg721ApprovalQuery({
   });
 }
 export interface Sg721OwnerOfQuery {
-  client?: Sg721QueryClient;
+  client: Sg721QueryClient | undefined;
   options?: Omit<UseQueryOptions<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -172,14 +172,14 @@ export function useSg721OwnerOfQuery({
 exports[`createReactQueryHooks 2`] = `
 "export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
 export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
 }: Sg721CollectionInfoQuery) {
-  return useQuery<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client?.contractAddress], () => client ? client.collectionInfo() : undefined, { ...options,
+  return useQuery<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client?.contractAddress], () => client ? client.collectionInfo() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -188,7 +188,7 @@ export function useSg721MinterQuery({
   client,
   options
 }: Sg721MinterQuery) {
-  return useQuery<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client?.contractAddress], () => client ? client.minter() : undefined, { ...options,
+  return useQuery<MinterResponse, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client?.contractAddress], () => client ? client.minter() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -203,10 +203,10 @@ export function useSg721AllTokensQuery({
   args,
   options
 }: Sg721AllTokensQuery) {
-  return useQuery<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>([\\"sg721AllTokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allTokens({
+  return useQuery<AllTokensResponse, Error, AllTokensResponse, (string | undefined)[]>([\\"sg721AllTokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allTokens({
     limit: args.limit,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -222,11 +222,11 @@ export function useSg721TokensQuery({
   args,
   options
 }: Sg721TokensQuery) {
-  return useQuery<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>([\\"sg721Tokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.tokens({
+  return useQuery<TokensResponse, Error, TokensResponse, (string | undefined)[]>([\\"sg721Tokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.tokens({
     limit: args.limit,
     owner: args.owner,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -241,10 +241,10 @@ export function useSg721AllNftInfoQuery({
   args,
   options
 }: Sg721AllNftInfoQuery) {
-  return useQuery<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>([\\"sg721AllNftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allNftInfo({
+  return useQuery<AllNftInfoResponse, Error, AllNftInfoResponse, (string | undefined)[]>([\\"sg721AllNftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allNftInfo({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -258,9 +258,9 @@ export function useSg721NftInfoQuery({
   args,
   options
 }: Sg721NftInfoQuery) {
-  return useQuery<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>([\\"sg721NftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.nftInfo({
+  return useQuery<NftInfoResponse, Error, NftInfoResponse, (string | undefined)[]>([\\"sg721NftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.nftInfo({
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -269,7 +269,7 @@ export function useSg721ContractInfoQuery({
   client,
   options
 }: Sg721ContractInfoQuery) {
-  return useQuery<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client?.contractAddress], () => client ? client.contractInfo() : undefined, { ...options,
+  return useQuery<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client?.contractAddress], () => client ? client.contractInfo() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -278,7 +278,7 @@ export function useSg721NumTokensQuery({
   client,
   options
 }: Sg721NumTokensQuery) {
-  return useQuery<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client?.contractAddress], () => client ? client.numTokens() : undefined, { ...options,
+  return useQuery<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client?.contractAddress], () => client ? client.numTokens() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -295,12 +295,12 @@ export function useSg721AllOperatorsQuery({
   args,
   options
 }: Sg721AllOperatorsQuery) {
-  return useQuery<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>([\\"sg721AllOperators\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allOperators({
+  return useQuery<AllOperatorsResponse, Error, AllOperatorsResponse, (string | undefined)[]>([\\"sg721AllOperators\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allOperators({
     includeExpired: args.includeExpired,
     limit: args.limit,
     owner: args.owner,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -315,10 +315,10 @@ export function useSg721ApprovalsQuery({
   args,
   options
 }: Sg721ApprovalsQuery) {
-  return useQuery<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>([\\"sg721Approvals\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approvals({
+  return useQuery<ApprovalsResponse, Error, ApprovalsResponse, (string | undefined)[]>([\\"sg721Approvals\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approvals({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -334,11 +334,11 @@ export function useSg721ApprovalQuery({
   args,
   options
 }: Sg721ApprovalQuery) {
-  return useQuery<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>([\\"sg721Approval\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approval({
+  return useQuery<ApprovalResponse, Error, ApprovalResponse, (string | undefined)[]>([\\"sg721Approval\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approval({
     includeExpired: args.includeExpired,
     spender: args.spender,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -353,10 +353,10 @@ export function useSg721OwnerOfQuery({
   args,
   options
 }: Sg721OwnerOfQuery) {
-  return useQuery<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>([\\"sg721OwnerOf\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.ownerOf({
+  return useQuery<OwnerOfResponse, Error, OwnerOfResponse, (string | undefined)[]>([\\"sg721OwnerOf\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.ownerOf({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }"
@@ -536,7 +536,7 @@ export function useSg721OwnerOfQuery({
 exports[`createReactQueryHooks 4`] = `
 "export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
+  options?: Omit<UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
 }
@@ -545,7 +545,7 @@ export function useSg721CollectionInfoQuery({
   client,
   options
 }: Sg721CollectionInfoQuery) {
-  return useQuery<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client?.contractAddress], () => client ? client.collectionInfo() : undefined, { ...options,
+  return useQuery<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client?.contractAddress], () => client ? client.collectionInfo() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -554,7 +554,7 @@ export function useSg721MinterQuery({
   client,
   options
 }: Sg721MinterQuery) {
-  return useQuery<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client?.contractAddress], () => client ? client.minter() : undefined, { ...options,
+  return useQuery<MinterResponse, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client?.contractAddress], () => client ? client.minter() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -569,10 +569,10 @@ export function useSg721AllTokensQuery({
   args,
   options
 }: Sg721AllTokensQuery) {
-  return useQuery<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>([\\"sg721AllTokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allTokens({
+  return useQuery<AllTokensResponse, Error, AllTokensResponse, (string | undefined)[]>([\\"sg721AllTokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allTokens({
     limit: args.limit,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -588,11 +588,11 @@ export function useSg721TokensQuery({
   args,
   options
 }: Sg721TokensQuery) {
-  return useQuery<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>([\\"sg721Tokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.tokens({
+  return useQuery<TokensResponse, Error, TokensResponse, (string | undefined)[]>([\\"sg721Tokens\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.tokens({
     limit: args.limit,
     owner: args.owner,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -607,10 +607,10 @@ export function useSg721AllNftInfoQuery({
   args,
   options
 }: Sg721AllNftInfoQuery) {
-  return useQuery<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>([\\"sg721AllNftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allNftInfo({
+  return useQuery<AllNftInfoResponse, Error, AllNftInfoResponse, (string | undefined)[]>([\\"sg721AllNftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allNftInfo({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -624,9 +624,9 @@ export function useSg721NftInfoQuery({
   args,
   options
 }: Sg721NftInfoQuery) {
-  return useQuery<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>([\\"sg721NftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.nftInfo({
+  return useQuery<NftInfoResponse, Error, NftInfoResponse, (string | undefined)[]>([\\"sg721NftInfo\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.nftInfo({
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -635,7 +635,7 @@ export function useSg721ContractInfoQuery({
   client,
   options
 }: Sg721ContractInfoQuery) {
-  return useQuery<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client?.contractAddress], () => client ? client.contractInfo() : undefined, { ...options,
+  return useQuery<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client?.contractAddress], () => client ? client.contractInfo() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -644,7 +644,7 @@ export function useSg721NumTokensQuery({
   client,
   options
 }: Sg721NumTokensQuery) {
-  return useQuery<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client?.contractAddress], () => client ? client.numTokens() : undefined, { ...options,
+  return useQuery<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client?.contractAddress], () => client ? client.numTokens() : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -661,12 +661,12 @@ export function useSg721AllOperatorsQuery({
   args,
   options
 }: Sg721AllOperatorsQuery) {
-  return useQuery<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>([\\"sg721AllOperators\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allOperators({
+  return useQuery<AllOperatorsResponse, Error, AllOperatorsResponse, (string | undefined)[]>([\\"sg721AllOperators\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.allOperators({
     includeExpired: args.includeExpired,
     limit: args.limit,
     owner: args.owner,
     startAfter: args.startAfter
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -681,10 +681,10 @@ export function useSg721ApprovalsQuery({
   args,
   options
 }: Sg721ApprovalsQuery) {
-  return useQuery<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>([\\"sg721Approvals\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approvals({
+  return useQuery<ApprovalsResponse, Error, ApprovalsResponse, (string | undefined)[]>([\\"sg721Approvals\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approvals({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -700,11 +700,11 @@ export function useSg721ApprovalQuery({
   args,
   options
 }: Sg721ApprovalQuery) {
-  return useQuery<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>([\\"sg721Approval\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approval({
+  return useQuery<ApprovalResponse, Error, ApprovalResponse, (string | undefined)[]>([\\"sg721Approval\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.approval({
     includeExpired: args.includeExpired,
     spender: args.spender,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
@@ -719,10 +719,10 @@ export function useSg721OwnerOfQuery({
   args,
   options
 }: Sg721OwnerOfQuery) {
-  return useQuery<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>([\\"sg721OwnerOf\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.ownerOf({
+  return useQuery<OwnerOfResponse, Error, OwnerOfResponse, (string | undefined)[]>([\\"sg721OwnerOf\\", client?.contractAddress, JSON.stringify(args)], () => client ? client.ownerOf({
     includeExpired: args.includeExpired,
     tokenId: args.tokenId
-  }) : undefined, { ...options,
+  }) : Promise.reject(new Error(\\"Invalid client\\")), { ...options,
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }"

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -1,29 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createReactQueryHooks 1`] = `
-"export interface Sg721CollectionInfoQuery {
+"export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient;
-  options?: UseQueryOptions<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
 }
+export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
 }: Sg721CollectionInfoQuery) {
   return useQuery<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client.contractAddress], () => client.collectionInfo(), options);
 }
-export interface Sg721MinterQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<MinterResponse, Error, MinterResponse, (string | undefined)[]>;
-}
+export interface Sg721MinterQuery extends Sg721ReactQuery<MinterResponse> {}
 export function useSg721MinterQuery({
   client,
   options
 }: Sg721MinterQuery) {
   return useQuery<MinterResponse, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client.contractAddress], () => client.minter(), options);
 }
-export interface Sg721AllTokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllTokensResponse, Error, AllTokensResponse, (string | undefined)[]>;
+export interface Sg721AllTokensQuery extends Sg721ReactQuery<AllTokensResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -39,9 +35,7 @@ export function useSg721AllTokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721TokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<TokensResponse, Error, TokensResponse, (string | undefined)[]>;
+export interface Sg721TokensQuery extends Sg721ReactQuery<TokensResponse> {
   args: {
     limit?: number;
     owner: string;
@@ -59,9 +53,7 @@ export function useSg721TokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721AllNftInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllNftInfoResponse, Error, AllNftInfoResponse, (string | undefined)[]>;
+export interface Sg721AllNftInfoQuery extends Sg721ReactQuery<AllNftInfoResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -77,9 +69,7 @@ export function useSg721AllNftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721NftInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<NftInfoResponse, Error, NftInfoResponse, (string | undefined)[]>;
+export interface Sg721NftInfoQuery extends Sg721ReactQuery<NftInfoResponse> {
   args: {
     tokenId: string;
   };
@@ -93,29 +83,21 @@ export function useSg721NftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ContractInfoQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>;
-}
+export interface Sg721ContractInfoQuery extends Sg721ReactQuery<ContractInfoResponse> {}
 export function useSg721ContractInfoQuery({
   client,
   options
 }: Sg721ContractInfoQuery) {
   return useQuery<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client.contractAddress], () => client.contractInfo(), options);
 }
-export interface Sg721NumTokensQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>;
-}
+export interface Sg721NumTokensQuery extends Sg721ReactQuery<NumTokensResponse> {}
 export function useSg721NumTokensQuery({
   client,
   options
 }: Sg721NumTokensQuery) {
   return useQuery<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client.contractAddress], () => client.numTokens(), options);
 }
-export interface Sg721AllOperatorsQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<AllOperatorsResponse, Error, AllOperatorsResponse, (string | undefined)[]>;
+export interface Sg721AllOperatorsQuery extends Sg721ReactQuery<AllOperatorsResponse> {
   args: {
     includeExpired?: boolean;
     limit?: number;
@@ -135,9 +117,7 @@ export function useSg721AllOperatorsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721ApprovalsQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ApprovalsResponse, Error, ApprovalsResponse, (string | undefined)[]>;
+export interface Sg721ApprovalsQuery extends Sg721ReactQuery<ApprovalsResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -153,9 +133,7 @@ export function useSg721ApprovalsQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ApprovalQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<ApprovalResponse, Error, ApprovalResponse, (string | undefined)[]>;
+export interface Sg721ApprovalQuery extends Sg721ReactQuery<ApprovalResponse> {
   args: {
     includeExpired?: boolean;
     spender: string;
@@ -173,9 +151,7 @@ export function useSg721ApprovalQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721OwnerOfQuery {
-  client: Sg721QueryClient;
-  options?: UseQueryOptions<OwnerOfResponse, Error, OwnerOfResponse, (string | undefined)[]>;
+export interface Sg721OwnerOfQuery extends Sg721ReactQuery<OwnerOfResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -194,10 +170,11 @@ export function useSg721OwnerOfQuery({
 `;
 
 exports[`createReactQueryHooks 2`] = `
-"export interface Sg721CollectionInfoQuery {
+"export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>;
+  options?: UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>;
 }
+export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
@@ -206,10 +183,7 @@ export function useSg721CollectionInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721MinterQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>;
-}
+export interface Sg721MinterQuery extends Sg721ReactQuery<MinterResponse> {}
 export function useSg721MinterQuery({
   client,
   options
@@ -218,9 +192,7 @@ export function useSg721MinterQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllTokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>;
+export interface Sg721AllTokensQuery extends Sg721ReactQuery<AllTokensResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -238,9 +210,7 @@ export function useSg721AllTokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721TokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>;
+export interface Sg721TokensQuery extends Sg721ReactQuery<TokensResponse> {
   args: {
     limit?: number;
     owner: string;
@@ -260,9 +230,7 @@ export function useSg721TokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllNftInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>;
+export interface Sg721AllNftInfoQuery extends Sg721ReactQuery<AllNftInfoResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -280,9 +248,7 @@ export function useSg721AllNftInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721NftInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>;
+export interface Sg721NftInfoQuery extends Sg721ReactQuery<NftInfoResponse> {
   args: {
     tokenId: string;
   };
@@ -298,10 +264,7 @@ export function useSg721NftInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ContractInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>;
-}
+export interface Sg721ContractInfoQuery extends Sg721ReactQuery<ContractInfoResponse> {}
 export function useSg721ContractInfoQuery({
   client,
   options
@@ -310,10 +273,7 @@ export function useSg721ContractInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721NumTokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>;
-}
+export interface Sg721NumTokensQuery extends Sg721ReactQuery<NumTokensResponse> {}
 export function useSg721NumTokensQuery({
   client,
   options
@@ -322,9 +282,7 @@ export function useSg721NumTokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllOperatorsQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>;
+export interface Sg721AllOperatorsQuery extends Sg721ReactQuery<AllOperatorsResponse> {
   args: {
     includeExpired?: boolean;
     limit?: number;
@@ -346,9 +304,7 @@ export function useSg721AllOperatorsQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ApprovalsQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>;
+export interface Sg721ApprovalsQuery extends Sg721ReactQuery<ApprovalsResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -366,9 +322,7 @@ export function useSg721ApprovalsQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ApprovalQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>;
+export interface Sg721ApprovalQuery extends Sg721ReactQuery<ApprovalResponse> {
   args: {
     includeExpired?: boolean;
     spender: string;
@@ -388,9 +342,7 @@ export function useSg721ApprovalQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721OwnerOfQuery {
-  client: Sg721QueryClient | undefined;
-  options?: UseQueryOptions<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>;
+export interface Sg721OwnerOfQuery extends Sg721ReactQuery<OwnerOfResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -411,35 +363,27 @@ export function useSg721OwnerOfQuery({
 `;
 
 exports[`createReactQueryHooks 3`] = `
-"export interface Sg721CollectionInfoQuery {
+"export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
+  options?: Omit<UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
 }
+export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
 }: Sg721CollectionInfoQuery) {
   return useQuery<CollectionInfoResponse, Error, CollectionInfoResponse, (string | undefined)[]>([\\"sg721CollectionInfo\\", client.contractAddress], () => client.collectionInfo(), options);
 }
-export interface Sg721MinterQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<MinterResponse, Error, MinterResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721MinterQuery extends Sg721ReactQuery<MinterResponse> {}
 export function useSg721MinterQuery({
   client,
   options
 }: Sg721MinterQuery) {
   return useQuery<MinterResponse, Error, MinterResponse, (string | undefined)[]>([\\"sg721Minter\\", client.contractAddress], () => client.minter(), options);
 }
-export interface Sg721AllTokensQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<AllTokensResponse, Error, AllTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllTokensQuery extends Sg721ReactQuery<AllTokensResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -455,11 +399,7 @@ export function useSg721AllTokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721TokensQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<TokensResponse, Error, TokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721TokensQuery extends Sg721ReactQuery<TokensResponse> {
   args: {
     limit?: number;
     owner: string;
@@ -477,11 +417,7 @@ export function useSg721TokensQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721AllNftInfoQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<AllNftInfoResponse, Error, AllNftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllNftInfoQuery extends Sg721ReactQuery<AllNftInfoResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -497,11 +433,7 @@ export function useSg721AllNftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721NftInfoQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<NftInfoResponse, Error, NftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721NftInfoQuery extends Sg721ReactQuery<NftInfoResponse> {
   args: {
     tokenId: string;
   };
@@ -515,35 +447,21 @@ export function useSg721NftInfoQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ContractInfoQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721ContractInfoQuery extends Sg721ReactQuery<ContractInfoResponse> {}
 export function useSg721ContractInfoQuery({
   client,
   options
 }: Sg721ContractInfoQuery) {
   return useQuery<ContractInfoResponse, Error, ContractInfoResponse, (string | undefined)[]>([\\"sg721ContractInfo\\", client.contractAddress], () => client.contractInfo(), options);
 }
-export interface Sg721NumTokensQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721NumTokensQuery extends Sg721ReactQuery<NumTokensResponse> {}
 export function useSg721NumTokensQuery({
   client,
   options
 }: Sg721NumTokensQuery) {
   return useQuery<NumTokensResponse, Error, NumTokensResponse, (string | undefined)[]>([\\"sg721NumTokens\\", client.contractAddress], () => client.numTokens(), options);
 }
-export interface Sg721AllOperatorsQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<AllOperatorsResponse, Error, AllOperatorsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllOperatorsQuery extends Sg721ReactQuery<AllOperatorsResponse> {
   args: {
     includeExpired?: boolean;
     limit?: number;
@@ -563,11 +481,7 @@ export function useSg721AllOperatorsQuery({
     startAfter: args.startAfter
   }), options);
 }
-export interface Sg721ApprovalsQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<ApprovalsResponse, Error, ApprovalsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721ApprovalsQuery extends Sg721ReactQuery<ApprovalsResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -583,11 +497,7 @@ export function useSg721ApprovalsQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721ApprovalQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<ApprovalResponse, Error, ApprovalResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721ApprovalQuery extends Sg721ReactQuery<ApprovalResponse> {
   args: {
     includeExpired?: boolean;
     spender: string;
@@ -605,11 +515,7 @@ export function useSg721ApprovalQuery({
     tokenId: args.tokenId
   }), options);
 }
-export interface Sg721OwnerOfQuery {
-  client: Sg721QueryClient;
-  options?: Omit<UseQueryOptions<OwnerOfResponse, Error, OwnerOfResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721OwnerOfQuery extends Sg721ReactQuery<OwnerOfResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -628,12 +534,13 @@ export function useSg721OwnerOfQuery({
 `;
 
 exports[`createReactQueryHooks 4`] = `
-"export interface Sg721CollectionInfoQuery {
+"export interface Sg721ReactQuery<TResponse> {
   client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<CollectionInfoResponse | undefined, Error, CollectionInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
+  options?: Omit<UseQueryOptions<TResponse | undefined, Error, TResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
     initialData?: undefined;
   };
 }
+export interface Sg721CollectionInfoQuery extends Sg721ReactQuery<CollectionInfoResponse> {}
 export function useSg721CollectionInfoQuery({
   client,
   options
@@ -642,12 +549,7 @@ export function useSg721CollectionInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721MinterQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<MinterResponse | undefined, Error, MinterResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721MinterQuery extends Sg721ReactQuery<MinterResponse> {}
 export function useSg721MinterQuery({
   client,
   options
@@ -656,11 +558,7 @@ export function useSg721MinterQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllTokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<AllTokensResponse | undefined, Error, AllTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllTokensQuery extends Sg721ReactQuery<AllTokensResponse> {
   args: {
     limit?: number;
     startAfter?: string;
@@ -678,11 +576,7 @@ export function useSg721AllTokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721TokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<TokensResponse | undefined, Error, TokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721TokensQuery extends Sg721ReactQuery<TokensResponse> {
   args: {
     limit?: number;
     owner: string;
@@ -702,11 +596,7 @@ export function useSg721TokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllNftInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<AllNftInfoResponse | undefined, Error, AllNftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllNftInfoQuery extends Sg721ReactQuery<AllNftInfoResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -724,11 +614,7 @@ export function useSg721AllNftInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721NftInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<NftInfoResponse | undefined, Error, NftInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721NftInfoQuery extends Sg721ReactQuery<NftInfoResponse> {
   args: {
     tokenId: string;
   };
@@ -744,12 +630,7 @@ export function useSg721NftInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ContractInfoQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<ContractInfoResponse | undefined, Error, ContractInfoResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721ContractInfoQuery extends Sg721ReactQuery<ContractInfoResponse> {}
 export function useSg721ContractInfoQuery({
   client,
   options
@@ -758,12 +639,7 @@ export function useSg721ContractInfoQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721NumTokensQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<NumTokensResponse | undefined, Error, NumTokensResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
-}
+export interface Sg721NumTokensQuery extends Sg721ReactQuery<NumTokensResponse> {}
 export function useSg721NumTokensQuery({
   client,
   options
@@ -772,11 +648,7 @@ export function useSg721NumTokensQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721AllOperatorsQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<AllOperatorsResponse | undefined, Error, AllOperatorsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721AllOperatorsQuery extends Sg721ReactQuery<AllOperatorsResponse> {
   args: {
     includeExpired?: boolean;
     limit?: number;
@@ -798,11 +670,7 @@ export function useSg721AllOperatorsQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ApprovalsQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<ApprovalsResponse | undefined, Error, ApprovalsResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721ApprovalsQuery extends Sg721ReactQuery<ApprovalsResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;
@@ -820,11 +688,7 @@ export function useSg721ApprovalsQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721ApprovalQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<ApprovalResponse | undefined, Error, ApprovalResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721ApprovalQuery extends Sg721ReactQuery<ApprovalResponse> {
   args: {
     includeExpired?: boolean;
     spender: string;
@@ -844,11 +708,7 @@ export function useSg721ApprovalQuery({
     enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
   });
 }
-export interface Sg721OwnerOfQuery {
-  client: Sg721QueryClient | undefined;
-  options?: Omit<UseQueryOptions<OwnerOfResponse | undefined, Error, OwnerOfResponse, (string | undefined)[]>, \\"'queryKey' | 'queryFn' | 'initialData'\\"> & {
-    initialData?: undefined;
-  };
+export interface Sg721OwnerOfQuery extends Sg721ReactQuery<OwnerOfResponse> {
   args: {
     includeExpired?: boolean;
     tokenId: string;

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -40,12 +40,22 @@ export const createReactQueryHooks = ({
 }: ReactQueryHooks) => {
     const options = context.options.reactQuery;
 
-    return getMessageProperties(queryMsg)
+    const genericQueryInterfaceName = `${pascal(contractName)}ReactQuery`;
+
+    const body = [
+      createReactQueryHookGenericInterface({
+        context,
+        QueryClient,
+        genericQueryInterfaceName,
+      })
+    ]
+
+    body.push(...getMessageProperties(queryMsg)
         .reduce((m, schema) => {
             const underscoreName = Object.keys(schema.properties)[0];
             const methodName = camel(underscoreName);
-            const hookName = `use${pascal(contractName)}${pascal(methodName)}Query`;
             const hookParamsTypeName = `${pascal(contractName)}${pascal(methodName)}Query`;
+            const hookName = `use${hookParamsTypeName}`;
             const responseType = pascal(`${methodName}Response`);
             const getterKey = camel(`${contractName}${pascal(methodName)}`);
             const jsonschema = schema.properties[underscoreName];
@@ -54,9 +64,9 @@ export const createReactQueryHooks = ({
                     context,
                     hookParamsTypeName,
                     responseType,
+                    queryInterfaceName: genericQueryInterfaceName,
                     QueryClient,
                     jsonschema,
-                    options
                 }),
                 createReactQueryHook({
                     context,
@@ -69,7 +79,10 @@ export const createReactQueryHooks = ({
                 }),
                 ...m,
             ]
-        }, []);
+        }, [])
+    );
+
+    return body
 };
 
 
@@ -491,10 +504,101 @@ export const createReactQueryMutationHook = ({
 
 };
 
+interface ReactQueryHookGenericInterface{
+  context: RenderContext,
+  QueryClient: string,
+  genericQueryInterfaceName: string
+}
+
+function createReactQueryHookGenericInterface({
+  context,
+  QueryClient,
+  genericQueryInterfaceName
+}: ReactQueryHookGenericInterface) {
+
+  const options = context.options.reactQuery;
+
+  const genericTypeName = 'TResponse'
+
+  context.addUtil('UseQueryOptions');
+
+  const typedUseQueryOptions = t.tsTypeReference(
+    t.identifier('UseQueryOptions'),
+    t.tsTypeParameterInstantiation([
+      typeRefOrOptionalUnion(
+        t.identifier(genericTypeName),
+        options.optionalClient
+      ),
+      t.tsTypeReference(t.identifier('Error')),
+      t.tsTypeReference(
+        t.identifier(genericTypeName)
+      ),
+      t.tsArrayType(
+        t.tsParenthesizedType(
+          t.tsUnionType([
+            t.tsStringKeyword(),
+            t.tsUndefinedKeyword()
+          ])
+        )
+      ),
+    ])
+  )
+
+  const body = [
+    tsPropertySignature(
+      t.identifier('client'),
+      t.tsTypeAnnotation(
+        options.optionalClient
+          ? t.tsUnionType([
+            t.tsTypeReference(
+              t.identifier(QueryClient)
+            ),
+            t.tsUndefinedKeyword()
+          ])
+          : t.tsTypeReference(
+            t.identifier(QueryClient)
+          )
+      ),
+      false
+    ),
+    tsPropertySignature(
+      t.identifier('options'),
+      t.tsTypeAnnotation(
+        options.version === 'v4'
+          ? t.tSIntersectionType([
+            omitTypeReference(typedUseQueryOptions, "'queryKey' | 'queryFn' | 'initialData'"),
+            t.tSTypeLiteral([
+              t.tsPropertySignature(
+                t.identifier('initialData?'),
+                t.tsTypeAnnotation(
+                  t.tsUndefinedKeyword()
+                )
+              )
+            ])
+          ])
+          : typedUseQueryOptions
+      ),
+      true
+    )
+  ];
+
+  return t.exportNamedDeclaration(
+    t.tsInterfaceDeclaration(
+      t.identifier(genericQueryInterfaceName),
+      t.tsTypeParameterDeclaration([
+        t.tsTypeParameter(undefined, undefined, genericTypeName)
+      ]),
+      [],
+      t.tSInterfaceBody(body)
+    )
+  )
+}
+
 interface ReactQueryHookQueryInterface {
     context: RenderContext,
     QueryClient: string;
     hookParamsTypeName: string;
+    queryInterfaceName: string
     responseType: string;
     jsonschema: any;
 }
@@ -503,73 +607,14 @@ export const createReactQueryHookInterface = ({
     context,
     QueryClient,
     hookParamsTypeName,
+    queryInterfaceName,
     responseType,
     jsonschema
 }: ReactQueryHookQueryInterface) => {
     // merge the user options with the defaults
     const options = context.options.reactQuery;
 
-    context.addUtil('UseQueryOptions');
-
-    const typedUseQueryOptions = t.tsTypeReference(
-        t.identifier('UseQueryOptions'),
-        t.tsTypeParameterInstantiation([
-            typeRefOrOptionalUnion(
-                t.identifier(responseType),
-                options.optionalClient
-            ),
-            t.tsTypeReference(t.identifier('Error')),
-            t.tsTypeReference(
-                t.identifier(responseType)
-            ),
-            t.tsArrayType(
-                t.tsParenthesizedType(
-                    t.tsUnionType([
-                        t.tsStringKeyword(),
-                        t.tsUndefinedKeyword()
-                    ])
-                )
-            ),
-        ])
-    )
-
-    const body = [
-        tsPropertySignature(
-            t.identifier('client'),
-            t.tsTypeAnnotation(
-          options.optionalClient
-            ? t.tsUnionType([
-              t.tsTypeReference(
-                t.identifier(QueryClient)
-              ),
-              t.tsUndefinedKeyword()
-            ])
-            : t.tsTypeReference(
-                    t.identifier(QueryClient)
-                )
-            ),
-            false
-        ),
-        tsPropertySignature(
-            t.identifier('options'),
-            t.tsTypeAnnotation(
-                options.version === 'v4'
-                    ? t.tSIntersectionType([
-                        omitTypeReference(typedUseQueryOptions, "'queryKey' | 'queryFn' | 'initialData'"),
-                        t.tSTypeLiteral([
-                            t.tsPropertySignature(
-                                t.identifier('initialData?'),
-                                t.tsTypeAnnotation(
-                                    t.tsUndefinedKeyword()
-                                )
-                            )
-                        ])
-                    ])
-                    : typedUseQueryOptions
-            ),
-            true
-        )
-    ];
+    const body = []
 
     const props = getProps(context, jsonschema);
     if (props.length) {
@@ -582,14 +627,23 @@ export const createReactQueryHookInterface = ({
     }
 
 
-    return t.exportNamedDeclaration(t.tsInterfaceDeclaration(
+    return t.exportNamedDeclaration(
+      t.tsInterfaceDeclaration(
         t.identifier(hookParamsTypeName),
         null,
-        [],
+      [
+          t.tSExpressionWithTypeArguments(
+            t.identifier(queryInterfaceName),
+            t.tsTypeParameterInstantiation([
+              t.tsTypeReference(t.identifier(responseType))
+            ])
+          )
+        ],
         t.tsInterfaceBody(
             body
         )
-    ))
+      )
+    )
 };
 
 const getProps = (

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -537,11 +537,18 @@ export const createReactQueryHookInterface = ({
         tsPropertySignature(
             t.identifier('client'),
             t.tsTypeAnnotation(
-                t.tsTypeReference(
+          options.optionalClient
+            ? t.tsUnionType([
+              t.tsTypeReference(
+                t.identifier(QueryClient)
+              ),
+              t.tsUndefinedKeyword()
+            ])
+            : t.tsTypeReference(
                     t.identifier(QueryClient)
                 )
             ),
-            options.optionalClient
+            false
         ),
         tsPropertySignature(
             t.identifier('options'),

--- a/packages/wasm-ast-types/src/utils/babel.ts
+++ b/packages/wasm-ast-types/src/utils/babel.ts
@@ -279,7 +279,7 @@ export const optionalConditionalExpression = (test: t.Expression, expression: t.
         : expression
 }
 
-export const typeRefOrOptionalUnion = (identifier: t.Identifier, optional: boolean = false): t.TSType => {
+export const typeRefOrUnionWithUndefined = (identifier: t.Identifier, optional: boolean = false): t.TSType => {
     const typeReference = t.tsTypeReference(identifier)
     return optional
         ? t.tsUnionType([


### PR DESCRIPTION
This change just cleans up the react-query generation so that users may more easily extend it in their own application without a bunch of copy-pasting. It also reduces the complexity of the generated code with a new generic interface used by all the queries.

For example:
```ts
export interface CW4GroupReactQuery<TResponse> {
  client: CW4GroupQueryClient;
  options?: UseQueryOptions<TResponse, Error, TResponse, (string | undefined)[]>;
}

export interface CW4GroupListMembersQuery extends CW4GroupReactQuery<ListMembersResponse> {
  args: {
    limit?: number;
    startAfter?: string;
  };
}
```

Secondly, it updates the `optionalClient` generation to reject the promise instead of returning `undefined` (which was bad practice).

```ts
export function useFactoryAdminAddrQuery({
  client,
  options
}: FactoryAdminAddrQuery) {
  return useQuery<AdminAddrResponse, Error, AdminAddrResponse, (string | undefined)[]>(["factoryAdminAddr", client?.contractAddress], 
  () => client
    ? client.adminAddr()
    : Promise.reject(new Error("Invalid client")), 
  { 
    ...options,
    enabled: !!client && (options?.enabled != undefined ? options.enabled : true)
  });
}
```

Finally, it updates the optional client generation to have the following signature:
```ts
client: CW4GroupQueryClient | undefined
```
This is because we want to ensure the user actually includes the client in the query as opposed to it being an optional param.