### PR TITLE
Expand the referenced types for react query mutations

### DIFF
--- a/__output__/vectis/factory-w-mutations/Factory.react-query.ts
+++ b/__output__/vectis/factory-w-mutations/Factory.react-query.ts
@@ -6,7 +6,6 @@
 
 import { UseQueryOptions, useQuery, useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { ExecuteResult } from "@cosmjs/cosmwasm-stargate";
-import { StdFee } from "@cosmjs/amino";
 import { AdminAddrResponse, CodeIdResponse, CodeIdType, Uint128, Binary, CreateWalletMsg, Guardians, MultiSig, Coin, Cw20Coin, ExecuteMsg, Addr, ProxyMigrationTxMsg, WalletAddr, CanonicalAddr, RelayTransaction, FeeResponse, GovecAddrResponse, InstantiateMsg, QueryMsg, WalletQueryPrefix, Duration, StakingOptions, WalletInfo, ContractVersion, WalletsOfResponse, WalletsResponse } from "./Factory.types";
 import { FactoryQueryClient, FactoryClient } from "./Factory.client";
 export interface FactoryReactQuery<TResponse, TData = TResponse> {

--- a/packages/ts-codegen/src/cmds.js
+++ b/packages/ts-codegen/src/cmds.js
@@ -1,4 +1,3 @@
-
 import _create_boilerplate from './commands/create-boilerplate';
 import _generate from './commands/generate';
 import _install from './commands/install';
@@ -7,6 +6,4 @@ Commands['create-boilerplate'] = _create_boilerplate;
 Commands['generate'] = _generate;
 Commands['install'] = _install;
 
-  export { Commands }; 
-
-  
+export { Commands };

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -1149,7 +1149,12 @@ export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteRe
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
-  msg: MintMsg_for_Empty;
+  msg: {
+    extension: Empty;
+    owner: string;
+    tokenId: string;
+    tokenUri?: string;
+  };
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -413,7 +413,6 @@ export const createReactQueryMutationArgsInterface = ({
     body.push(
       t.tsPropertySignature(
         t.identifier('msg'),
-        // @ts-ignore
         msgType
       ));
   }

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -4,11 +4,13 @@ import { camel, pascal } from 'case';
 import { ExecuteMsg, QueryMsg } from '../types';
 import {
   callExpression,
+  createTypedObjectParams,
   getMessageProperties,
   identifier,
   tsObjectPattern,
   tsPropertySignature
 } from '../utils';
+
 import {
   omitTypeReference,
   optionalConditionalExpression,
@@ -371,16 +373,17 @@ interface ReactQueryMutationHookInterface {
 /**
  * Example:
 ```
-export interface Cw4UpdateMembersMutation {
-  client: Cw4GroupClient
-  args: {
-    tokenId: string
-    remove: string[]
-  }
-  options?: Omit<
-    UseMutationOptions<ExecuteResult, Error, Pick<Cw4UpdateMembersMutation, 'args'>>,
-    'mutationFn'
-  >
+ export interface Cw721RevokeMutation {
+  client: Cw721Client;
+  msg: {
+    spender: string;
+    tokenId: string;
+  };
+  args?: {
+    fee?: number | StdFee | "auto";
+    memo?: string;
+    funds?: Coin[];
+  };
 }
 ```
  */
@@ -404,18 +407,16 @@ export const createReactQueryMutationArgsInterface = ({
     )
   ];
 
-  const msgType: t.TSTypeAnnotation = getParamsTypeAnnotation(
-    context,
-    jsonschema
-  );
+  const msgType = createTypedObjectParams(context, jsonschema).typeAnnotation as unknown as t.TSTypeAnnotation
 
   if (msgType) {
-    body.push(t.tsPropertySignature(t.identifier('msg'), msgType));
+    body.push(
+      t.tsPropertySignature(
+        t.identifier('msg'),
+        // @ts-ignore
+        msgType
+      ));
   }
-
-  context.addUtil('StdFee');
-  context.addUtil('Coin');
-  //  fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]
 
   const optionalArgs = t.tsPropertySignature(
     t.identifier('args'),


### PR DESCRIPTION
Fixes https://github.com/CosmWasm/ts-codegen/issues/80

The issue was that the previous method called did not resolve refs, meaning that they were not converted into camel case.