### PR TITLE
Update client and message composer to underscore funds to avoid conflicts

### DIFF
--- a/__fixtures__/issues/98/out/98.client.ts
+++ b/__fixtures__/issues/98/out/98.client.ts
@@ -75,7 +75,7 @@ export interface 98Interface extends 98ReadOnlyInterface {
   }: {
     id: number;
     instantiateMsg: Binary;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   registerPlugin: ({
     checksum,
     codeId,
@@ -90,12 +90,12 @@ export interface 98Interface extends 98ReadOnlyInterface {
     ipfsHash: string;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregisterPlugin: ({
     id
   }: {
     id: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePlugin: ({
     checksum,
     codeId,
@@ -112,17 +112,17 @@ export interface 98Interface extends 98ReadOnlyInterface {
     ipfsHash?: string;
     name?: string;
     version?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateRegistryFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateDaoAddr: ({
     newAddr
   }: {
     newAddr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class 98Client extends 98QueryClient implements 98Interface {
   client: SigningCosmWasmClient;
@@ -148,13 +148,13 @@ export class 98Client extends 98QueryClient implements 98Interface {
   }: {
     id: number;
     instantiateMsg: Binary;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proxy_install_plugin: {
         id,
         instantiate_msg: instantiateMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   registerPlugin = async ({
     checksum,
@@ -170,7 +170,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash: string;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register_plugin: {
         checksum,
@@ -180,18 +180,18 @@ export class 98Client extends 98QueryClient implements 98Interface {
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregisterPlugin = async ({
     id
   }: {
     id: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister_plugin: {
         id
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePlugin = async ({
     checksum,
@@ -209,7 +209,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash?: string;
     name?: string;
     version?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_plugin: {
         checksum,
@@ -220,28 +220,28 @@ export class 98Client extends 98QueryClient implements 98Interface {
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateRegistryFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_registry_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateDaoAddr = async ({
     newAddr
   }: {
     newAddr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_dao_addr: {
         new_addr: newAddr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
@@ -31,7 +31,7 @@ export interface CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -53,13 +53,13 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
   sender: string;
@@ -40,7 +40,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
@@ -109,7 +109,7 @@ export interface CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -122,7 +122,7 @@ export interface CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -131,21 +131,21 @@ export interface CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -171,14 +171,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   register = async ({
     chainId,
@@ -192,7 +192,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -201,7 +201,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setOwner = async ({
     chainId,
@@ -211,14 +211,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregister = async ({
     chainId,
@@ -226,13 +226,13 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     admin,
@@ -240,12 +240,12 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMessage {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMessage {
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMessage {
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage {
   sender: string;
@@ -80,7 +80,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -109,7 +109,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -159,7 +159,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwSingle.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.client.ts
@@ -176,24 +176,24 @@ export interface CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -210,27 +210,27 @@ export interface CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -260,14 +260,14 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -275,35 +275,35 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -321,7 +321,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -332,50 +332,50 @@ export class CwSingleClient implements CwSingleInterface {
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMessageComposer implements CwSingleMessage {
   sender: string;
@@ -101,7 +101,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -144,7 +144,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -163,7 +163,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -194,7 +194,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -219,7 +219,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -238,7 +238,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -257,7 +257,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -276,7 +276,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Factory.client.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.client.ts
@@ -114,43 +114,43 @@ export interface FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -174,12 +174,12 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateProxyUser = async ({
     newUser,
@@ -187,13 +187,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -201,13 +201,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateCodeId = async ({
     newCodeId,
@@ -215,45 +215,45 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMessageComposer implements FactoryMessage {
   sender: string;
@@ -73,7 +73,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -116,7 +116,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -138,7 +138,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -158,7 +158,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -177,7 +177,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -196,7 +196,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Minter.client.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.client.ts
@@ -68,31 +68,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -112,48 +112,48 @@ export class MinterClient implements MinterInterface {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintFor = async ({
     recipient,
@@ -161,17 +161,17 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMessage {
   contractAddress: string;
   sender: string;
-  mint: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMessageComposer implements MinterMessage {
   sender: string;
@@ -53,7 +53,7 @@ export class MinterMessageComposer implements MinterMessage {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -70,7 +70,7 @@ export class MinterMessageComposer implements MinterMessage {
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -81,11 +81,11 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  updateStartTime = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -102,7 +102,7 @@ export class MinterMessageComposer implements MinterMessage {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -121,7 +121,7 @@ export class MinterMessageComposer implements MinterMessage {
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -142,7 +142,7 @@ export class MinterMessageComposer implements MinterMessage {
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -154,11 +154,11 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  withdraw = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -81,7 +81,7 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -154,7 +154,7 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/default/CwAdminFactory.client.ts
+++ b/__output__/builder/default/CwAdminFactory.client.ts
@@ -31,7 +31,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -54,13 +54,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/default/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/default/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
   sender: string;
@@ -40,7 +40,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/default/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/default/CwAdminFactory.message-composer.ts
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/default/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.client.ts
@@ -109,7 +109,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -122,7 +122,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -131,21 +131,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -172,14 +172,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   register = async ({
     chainId,
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -202,7 +202,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setOwner = async ({
     chainId,
@@ -212,14 +212,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregister = async ({
     chainId,
@@ -227,13 +227,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     admin,
@@ -241,12 +241,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMessage {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMessage {
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMessage {
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage {
   sender: string;
@@ -80,7 +80,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -109,7 +109,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -159,7 +159,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/default/CwSingle.client.ts
+++ b/__output__/builder/default/CwSingle.client.ts
@@ -176,24 +176,24 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -210,27 +210,27 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient extends CwSingleQueryClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -261,14 +261,14 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -276,35 +276,35 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -322,7 +322,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -333,50 +333,50 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/default/CwSingle.message-composer.ts
+++ b/__output__/builder/default/CwSingle.message-composer.ts
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/default/CwSingle.message-composer.ts
+++ b/__output__/builder/default/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMessageComposer implements CwSingleMessage {
   sender: string;
@@ -101,7 +101,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -144,7 +144,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -163,7 +163,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -194,7 +194,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -219,7 +219,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -238,7 +238,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -257,7 +257,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -276,7 +276,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/default/Factory.client.ts
+++ b/__output__/builder/default/Factory.client.ts
@@ -114,43 +114,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -175,12 +175,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateProxyUser = async ({
     newUser,
@@ -188,13 +188,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -202,13 +202,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateCodeId = async ({
     newCodeId,
@@ -216,45 +216,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/default/Factory.message-composer.ts
+++ b/__output__/builder/default/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMessageComposer implements FactoryMessage {
   sender: string;
@@ -73,7 +73,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -116,7 +116,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -138,7 +138,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -158,7 +158,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -177,7 +177,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -196,7 +196,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/default/Factory.message-composer.ts
+++ b/__output__/builder/default/Factory.message-composer.ts
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/default/Minter.client.ts
+++ b/__output__/builder/default/Minter.client.ts
@@ -68,31 +68,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -113,48 +113,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintFor = async ({
     recipient,
@@ -162,17 +162,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/default/Minter.message-composer.ts
+++ b/__output__/builder/default/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMessage {
   contractAddress: string;
   sender: string;
-  mint: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMessageComposer implements MinterMessage {
   sender: string;
@@ -53,7 +53,7 @@ export class MinterMessageComposer implements MinterMessage {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -70,7 +70,7 @@ export class MinterMessageComposer implements MinterMessage {
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -81,11 +81,11 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  updateStartTime = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -102,7 +102,7 @@ export class MinterMessageComposer implements MinterMessage {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -121,7 +121,7 @@ export class MinterMessageComposer implements MinterMessage {
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -142,7 +142,7 @@ export class MinterMessageComposer implements MinterMessage {
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -154,11 +154,11 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  withdraw = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/default/Minter.message-composer.ts
+++ b/__output__/builder/default/Minter.message-composer.ts
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -81,7 +81,7 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -154,7 +154,7 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/invoke/CwAdminFactory.client.ts
+++ b/__output__/builder/invoke/CwAdminFactory.client.ts
@@ -31,7 +31,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -54,13 +54,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/invoke/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/invoke/CwCodeIdRegistry.client.ts
@@ -109,7 +109,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -122,7 +122,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -131,21 +131,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -172,14 +172,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   register = async ({
     chainId,
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -202,7 +202,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setOwner = async ({
     chainId,
@@ -212,14 +212,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregister = async ({
     chainId,
@@ -227,13 +227,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     admin,
@@ -241,12 +241,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/invoke/CwSingle.client.ts
+++ b/__output__/builder/invoke/CwSingle.client.ts
@@ -176,24 +176,24 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -210,27 +210,27 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient extends CwSingleQueryClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -261,14 +261,14 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -276,35 +276,35 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -322,7 +322,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -333,50 +333,50 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/invoke/Factory.client.ts
+++ b/__output__/builder/invoke/Factory.client.ts
@@ -114,43 +114,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -175,12 +175,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateProxyUser = async ({
     newUser,
@@ -188,13 +188,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -202,13 +202,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateCodeId = async ({
     newCodeId,
@@ -216,45 +216,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/invoke/Minter.client.ts
+++ b/__output__/builder/invoke/Minter.client.ts
@@ -68,31 +68,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -113,48 +113,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintFor = async ({
     recipient,
@@ -162,17 +162,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/CwAdminFactory.client.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.client.ts
@@ -31,7 +31,7 @@ export interface CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -53,13 +53,13 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
   sender: string;
@@ -40,7 +40,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
@@ -109,7 +109,7 @@ export interface CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -122,7 +122,7 @@ export interface CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -131,21 +131,21 @@ export interface CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -171,14 +171,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   register = async ({
     chainId,
@@ -192,7 +192,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -201,7 +201,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setOwner = async ({
     chainId,
@@ -211,14 +211,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregister = async ({
     chainId,
@@ -226,13 +226,13 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     admin,
@@ -240,12 +240,12 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMessage {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMessage {
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMessage {
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage {
   sender: string;
@@ -80,7 +80,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -109,7 +109,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -159,7 +159,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/no-extends/CwSingle.client.ts
+++ b/__output__/builder/no-extends/CwSingle.client.ts
@@ -176,24 +176,24 @@ export interface CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -210,27 +210,27 @@ export interface CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -260,14 +260,14 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -275,35 +275,35 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -321,7 +321,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -332,50 +332,50 @@ export class CwSingleClient implements CwSingleInterface {
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/CwSingle.message-composer.ts
+++ b/__output__/builder/no-extends/CwSingle.message-composer.ts
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/no-extends/CwSingle.message-composer.ts
+++ b/__output__/builder/no-extends/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMessageComposer implements CwSingleMessage {
   sender: string;
@@ -101,7 +101,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             title
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -136,7 +136,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             vote
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -144,7 +144,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -155,7 +155,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -163,7 +163,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -174,7 +174,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -194,7 +194,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -211,7 +211,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             threshold
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -219,7 +219,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -230,7 +230,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -238,7 +238,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -249,7 +249,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -257,7 +257,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -268,7 +268,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -276,7 +276,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -287,7 +287,7 @@ export class CwSingleMessageComposer implements CwSingleMessage {
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/no-extends/Factory.client.ts
+++ b/__output__/builder/no-extends/Factory.client.ts
@@ -114,43 +114,43 @@ export interface FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -174,12 +174,12 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateProxyUser = async ({
     newUser,
@@ -187,13 +187,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -201,13 +201,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateCodeId = async ({
     newCodeId,
@@ -215,45 +215,45 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/Factory.message-composer.ts
+++ b/__output__/builder/no-extends/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMessageComposer implements FactoryMessage {
   sender: string;
@@ -73,7 +73,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -116,7 +116,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -138,7 +138,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -158,7 +158,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -177,7 +177,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -196,7 +196,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/no-extends/Factory.message-composer.ts
+++ b/__output__/builder/no-extends/Factory.message-composer.ts
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/builder/no-extends/Minter.client.ts
+++ b/__output__/builder/no-extends/Minter.client.ts
@@ -68,31 +68,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -112,48 +112,48 @@ export class MinterClient implements MinterInterface {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintFor = async ({
     recipient,
@@ -161,17 +161,17 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/builder/no-extends/Minter.message-composer.ts
+++ b/__output__/builder/no-extends/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMessage {
   contractAddress: string;
   sender: string;
-  mint: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMessageComposer implements MinterMessage {
   sender: string;
@@ -53,7 +53,7 @@ export class MinterMessageComposer implements MinterMessage {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -70,7 +70,7 @@ export class MinterMessageComposer implements MinterMessage {
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -81,11 +81,11 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  updateStartTime = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -102,7 +102,7 @@ export class MinterMessageComposer implements MinterMessage {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -121,7 +121,7 @@ export class MinterMessageComposer implements MinterMessage {
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -142,7 +142,7 @@ export class MinterMessageComposer implements MinterMessage {
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -154,11 +154,11 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  withdraw = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/builder/no-extends/Minter.message-composer.ts
+++ b/__output__/builder/no-extends/Minter.message-composer.ts
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -81,7 +81,7 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -154,7 +154,7 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
@@ -31,7 +31,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -54,13 +54,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
   sender: string;
@@ -40,7 +40,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
@@ -53,7 +53,7 @@ export class CwAdminFactoryMessageComposer implements CwAdminFactoryMessage {
             label
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
@@ -109,7 +109,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -122,7 +122,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -131,21 +131,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -172,14 +172,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   register = async ({
     chainId,
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -202,7 +202,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setOwner = async ({
     chainId,
@@ -212,14 +212,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   unregister = async ({
     chainId,
@@ -227,13 +227,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     admin,
@@ -241,12 +241,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMessage {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMessage {
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMessage {
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage {
   sender: string;
@@ -80,7 +80,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             sender
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -109,7 +109,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     codeId: number;
     name: string;
     version: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -124,7 +124,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             version
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
     chainId: string;
     name: string;
     owner?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -149,7 +149,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             owner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -159,7 +159,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     chainId: string;
     codeId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             code_id: codeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class CwCodeIdRegistryMessageComposer implements CwCodeIdRegistryMessage 
             payment_info: paymentInfo
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
@@ -114,17 +114,17 @@ export interface CwNamedGroupsInterface extends CwNamedGroupsReadOnlyInterface {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwNamedGroupsInterface {
   client: SigningCosmWasmClient;
@@ -149,35 +149,35 @@ export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwN
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
@@ -20,17 +20,17 @@ export interface CwNamedGroupsMessage {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
   sender: string;
@@ -52,7 +52,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -65,7 +65,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             group
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -73,7 +73,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
     group
   }: {
     group: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -84,7 +84,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             group
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -92,7 +92,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
     owner
   }: {
     owner: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -103,7 +103,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             owner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
@@ -65,7 +65,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             group
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -84,7 +84,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             group
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -103,7 +103,7 @@ export class CwNamedGroupsMessageComposer implements CwNamedGroupsMessage {
             owner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
@@ -176,24 +176,24 @@ export interface CwProposalSingleInterface extends CwProposalSingleReadOnlyInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -210,27 +210,27 @@ export interface CwProposalSingleInterface extends CwProposalSingleReadOnlyInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwProposalSingleClient extends CwProposalSingleQueryClient implements CwProposalSingleInterface {
   client: SigningCosmWasmClient;
@@ -261,14 +261,14 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -276,35 +276,35 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -322,7 +322,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -333,50 +333,50 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
@@ -114,7 +114,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             title
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -136,7 +136,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             vote
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -155,7 +155,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -174,7 +174,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -211,7 +211,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             threshold
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -230,7 +230,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -249,7 +249,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -268,7 +268,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -287,7 +287,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwProposalSingleMessage {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwProposalSingleMessage {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwProposalSingleMessageComposer implements CwProposalSingleMessage {
   sender: string;
@@ -101,7 +101,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             title
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -124,7 +124,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -136,7 +136,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             vote
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -144,7 +144,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -155,7 +155,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -163,7 +163,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -174,7 +174,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -194,7 +194,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -211,7 +211,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             threshold
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -219,7 +219,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -230,7 +230,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -238,7 +238,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -249,7 +249,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -257,7 +257,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -268,7 +268,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -276,7 +276,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
     address
   }: {
     address: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -287,7 +287,7 @@ export class CwProposalSingleMessageComposer implements CwProposalSingleMessage 
             address
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/idl-version/accounts-nft/AccountsNft.client.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.client.ts
@@ -297,20 +297,20 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     newOwner
   }: {
     newOwner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  acceptOwnership: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  acceptOwnership: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     user
   }: {
     user: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -319,7 +319,7 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -328,31 +328,31 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class AccountsNftClient extends AccountsNftQueryClient implements AccountsNftInterface {
   client: SigningCosmWasmClient;
@@ -380,28 +380,28 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     newOwner
   }: {
     newOwner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         new_owner: newOwner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  acceptOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  acceptOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       accept_ownership: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     user
   }: {
     user: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         user
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   transferNft = async ({
     recipient,
@@ -409,13 +409,13 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -425,14 +425,14 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -442,14 +442,14 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -457,13 +457,13 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -471,34 +471,34 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
@@ -16,20 +16,20 @@ export interface AccountsNftMessage {
     newOwner
   }: {
     newOwner: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  acceptOwnership: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  acceptOwnership: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     user
   }: {
     user: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -38,7 +38,7 @@ export interface AccountsNftMessage {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -47,31 +47,31 @@ export interface AccountsNftMessage {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class AccountsNftMessageComposer implements AccountsNftMessage {
   sender: string;
@@ -96,7 +96,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     newOwner
   }: {
     newOwner: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -107,11 +107,11 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             new_owner: newOwner
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  acceptOwnership = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  acceptOwnership = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -120,7 +120,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
         msg: toUtf8(JSON.stringify({
           accept_ownership: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -128,7 +128,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     user
   }: {
     user: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -139,7 +139,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             user
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -149,7 +149,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -161,7 +161,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -173,7 +173,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -186,7 +186,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -198,7 +198,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -211,7 +211,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -221,7 +221,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -233,7 +233,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -243,7 +243,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -255,7 +255,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -263,7 +263,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -274,7 +274,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -282,7 +282,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -293,7 +293,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
@@ -107,7 +107,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             new_owner: newOwner
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -120,7 +120,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
         msg: toUtf8(JSON.stringify({
           accept_ownership: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -139,7 +139,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             user
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -161,7 +161,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -186,7 +186,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -211,7 +211,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -233,7 +233,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -255,7 +255,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -274,7 +274,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -293,7 +293,7 @@ export class AccountsNftMessageComposer implements AccountsNftMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
@@ -189,24 +189,24 @@ export interface Cw3FixedMultiSigInterface extends Cw3FixedMultiSigReadOnlyInter
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implements Cw3FixedMultiSigInterface {
   client: SigningCosmWasmClient;
@@ -234,7 +234,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -242,7 +242,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -250,34 +250,34 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
@@ -77,7 +77,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             title
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -99,7 +99,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             vote
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -118,7 +118,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -137,7 +137,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             proposal_id: proposalId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
@@ -21,24 +21,24 @@ export interface Cw3FixedMultiSigMessage {
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage {
   sender: string;
@@ -63,7 +63,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -77,7 +77,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             title
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -87,7 +87,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
   }: {
     proposalId: number;
     vote: Vote;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -99,7 +99,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             vote
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -107,7 +107,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -118,7 +118,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -126,7 +126,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
     proposalId
   }: {
     proposalId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -137,7 +137,7 @@ export class Cw3FixedMultiSigMessageComposer implements Cw3FixedMultiSigMessage 
             proposal_id: proposalId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/idl-version/cw4-group/Cw4Group.client.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.client.ts
@@ -92,24 +92,24 @@ export interface Cw4GroupInterface extends Cw4GroupReadOnlyInterface {
     admin
   }: {
     admin?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateMembers: ({
     add,
     remove
   }: {
     add: Member[];
     remove: string[];
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addHook: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeHook: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInterface {
   client: SigningCosmWasmClient;
@@ -131,12 +131,12 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
     admin
   }: {
     admin?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         admin
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateMembers = async ({
     add,
@@ -144,34 +144,34 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
   }: {
     add: Member[];
     remove: string[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_members: {
         add,
         remove
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addHook = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_hook: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeHook = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_hook: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
@@ -63,7 +63,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             admin
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -85,7 +85,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             remove
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -104,7 +104,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -123,7 +123,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
@@ -16,24 +16,24 @@ export interface Cw4GroupMessage {
     admin
   }: {
     admin?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateMembers: ({
     add,
     remove
   }: {
     add: Member[];
     remove: string[];
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addHook: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeHook: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Cw4GroupMessageComposer implements Cw4GroupMessage {
   sender: string;
@@ -52,7 +52,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
     admin
   }: {
     admin?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -63,7 +63,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             admin
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -73,7 +73,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
   }: {
     add: Member[];
     remove: string[];
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -85,7 +85,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             remove
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -93,7 +93,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -104,7 +104,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -112,7 +112,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -123,7 +123,7 @@ export class Cw4GroupMessageComposer implements Cw4GroupMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/idl-version/cyberpunk/CyberPunk.client.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.client.ts
@@ -36,8 +36,8 @@ export interface CyberPunkInterface extends CyberPunkReadOnlyInterface {
   }: {
     memCost: number;
     timeCost: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  mirrorEnv: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mirrorEnv: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkInterface {
   client: SigningCosmWasmClient;
@@ -59,17 +59,17 @@ export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkIn
   }: {
     memCost: number;
     timeCost: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       argon2: {
         mem_cost: memCost,
         time_cost: timeCost
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  mirrorEnv = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mirrorEnv = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mirror_env: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
@@ -18,8 +18,8 @@ export interface CyberPunkMessage {
   }: {
     memCost: number;
     timeCost: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  mirrorEnv: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mirrorEnv: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CyberPunkMessageComposer implements CyberPunkMessage {
   sender: string;
@@ -38,7 +38,7 @@ export class CyberPunkMessageComposer implements CyberPunkMessage {
   }: {
     memCost: number;
     timeCost: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -50,11 +50,11 @@ export class CyberPunkMessageComposer implements CyberPunkMessage {
             time_cost: timeCost
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  mirrorEnv = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mirrorEnv = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -63,7 +63,7 @@ export class CyberPunkMessageComposer implements CyberPunkMessage {
         msg: toUtf8(JSON.stringify({
           mirror_env: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
@@ -50,7 +50,7 @@ export class CyberPunkMessageComposer implements CyberPunkMessage {
             time_cost: timeCost
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -63,7 +63,7 @@ export class CyberPunkMessageComposer implements CyberPunkMessage {
         msg: toUtf8(JSON.stringify({
           mirror_env: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/idl-version/hackatom/HackAtom.client.ts
+++ b/__output__/idl-version/hackatom/HackAtom.client.ts
@@ -76,18 +76,18 @@ export class HackAtomQueryClient implements HackAtomReadOnlyInterface {
 export interface HackAtomInterface extends HackAtomReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  release: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  cpuLoop: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  storageLoop: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  memoryLoop: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  messageLoop: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  release: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  cpuLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  storageLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  memoryLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  messageLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allocateLargeMemory: ({
     pages
   }: {
     pages: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  panic: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  userErrorsInApiCalls: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  panic: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  userErrorsInApiCalls: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class HackAtomClient extends HackAtomQueryClient implements HackAtomInterface {
   client: SigningCosmWasmClient;
@@ -109,50 +109,50 @@ export class HackAtomClient extends HackAtomQueryClient implements HackAtomInter
     this.userErrorsInApiCalls = this.userErrorsInApiCalls.bind(this);
   }
 
-  release = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  release = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       release: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  cpuLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  cpuLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cpu_loop: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  storageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  storageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       storage_loop: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  memoryLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  memoryLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       memory_loop: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  messageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  messageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       message_loop: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allocateLargeMemory = async ({
     pages
   }: {
     pages: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allocate_large_memory: {
         pages
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  panic = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  panic = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       panic: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  userErrorsInApiCalls = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  userErrorsInApiCalls = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       user_errors_in_api_calls: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/idl-version/hackatom/HackAtom.message-composer.ts
+++ b/__output__/idl-version/hackatom/HackAtom.message-composer.ts
@@ -50,7 +50,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           release: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -63,7 +63,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           cpu_loop: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -76,7 +76,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           storage_loop: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -89,7 +89,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           memory_loop: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -102,7 +102,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           message_loop: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -121,7 +121,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
             pages
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -134,7 +134,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           panic: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -147,7 +147,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           user_errors_in_api_calls: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/idl-version/hackatom/HackAtom.message-composer.ts
+++ b/__output__/idl-version/hackatom/HackAtom.message-composer.ts
@@ -11,18 +11,18 @@ import { InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, SudoMsg, Uint128, Coi
 export interface HackAtomMessage {
   contractAddress: string;
   sender: string;
-  release: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  cpuLoop: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  storageLoop: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  memoryLoop: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  messageLoop: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  release: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  cpuLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  storageLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  memoryLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  messageLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   allocateLargeMemory: ({
     pages
   }: {
     pages: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  panic: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  userErrorsInApiCalls: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  panic: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  userErrorsInApiCalls: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class HackAtomMessageComposer implements HackAtomMessage {
   sender: string;
@@ -41,7 +41,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
     this.userErrorsInApiCalls = this.userErrorsInApiCalls.bind(this);
   }
 
-  release = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  release = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -50,11 +50,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           release: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  cpuLoop = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  cpuLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -63,11 +63,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           cpu_loop: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  storageLoop = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  storageLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -76,11 +76,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           storage_loop: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  memoryLoop = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  memoryLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -89,11 +89,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           memory_loop: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  messageLoop = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  messageLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -102,7 +102,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           message_loop: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -110,7 +110,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
     pages
   }: {
     pages: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -121,11 +121,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
             pages
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  panic = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  panic = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -134,11 +134,11 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           panic: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  userErrorsInApiCalls = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  userErrorsInApiCalls = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,7 +147,7 @@ export class HackAtomMessageComposer implements HackAtomMessage {
         msg: toUtf8(JSON.stringify({
           user_errors_in_api_calls: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/minter/Minter.client.ts
+++ b/__output__/minter/Minter.client.ts
@@ -68,31 +68,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -113,48 +113,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mintFor = async ({
     recipient,
@@ -162,17 +162,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/minter/Minter.message-composer.ts
+++ b/__output__/minter/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMessage {
   contractAddress: string;
   sender: string;
-  mint: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMessageComposer implements MinterMessage {
   sender: string;
@@ -53,7 +53,7 @@ export class MinterMessageComposer implements MinterMessage {
     this.withdraw = this.withdraw.bind(this);
   }
 
-  mint = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -70,7 +70,7 @@ export class MinterMessageComposer implements MinterMessage {
     whitelist
   }: {
     whitelist: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -81,11 +81,11 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  updateStartTime = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -102,7 +102,7 @@ export class MinterMessageComposer implements MinterMessage {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -121,7 +121,7 @@ export class MinterMessageComposer implements MinterMessage {
     recipient
   }: {
     recipient: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -142,7 +142,7 @@ export class MinterMessageComposer implements MinterMessage {
   }: {
     recipient: string;
     tokenId: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -154,11 +154,11 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  withdraw = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/minter/Minter.message-composer.ts
+++ b/__output__/minter/Minter.message-composer.ts
@@ -62,7 +62,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -81,7 +81,7 @@ export class MinterMessageComposer implements MinterMessage {
             whitelist
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -113,7 +113,7 @@ export class MinterMessageComposer implements MinterMessage {
             per_address_limit: perAddressLimit
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -132,7 +132,7 @@ export class MinterMessageComposer implements MinterMessage {
             recipient
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -154,7 +154,7 @@ export class MinterMessageComposer implements MinterMessage {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -167,7 +167,7 @@ export class MinterMessageComposer implements MinterMessage {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/sg721/Sg721.client.ts
+++ b/__output__/sg721/Sg721.client.ts
@@ -248,7 +248,7 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -257,7 +257,7 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -266,26 +266,26 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -296,12 +296,12 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   client: SigningCosmWasmClient;
@@ -329,13 +329,13 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -345,14 +345,14 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -362,14 +362,14 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -377,13 +377,13 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -391,24 +391,24 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -420,7 +420,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -428,17 +428,17 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/sg721/Sg721.message-composer.ts
+++ b/__output__/sg721/Sg721.message-composer.ts
@@ -18,7 +18,7 @@ export interface Sg721Message {
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -27,7 +27,7 @@ export interface Sg721Message {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -36,26 +36,26 @@ export interface Sg721Message {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     extension,
     owner,
@@ -66,12 +66,12 @@ export interface Sg721Message {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Sg721MessageComposer implements Sg721Message {
   sender: string;
@@ -96,7 +96,7 @@ export class Sg721MessageComposer implements Sg721Message {
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -108,7 +108,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -120,7 +120,7 @@ export class Sg721MessageComposer implements Sg721Message {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -133,7 +133,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -145,7 +145,7 @@ export class Sg721MessageComposer implements Sg721Message {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -158,7 +158,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -168,7 +168,7 @@ export class Sg721MessageComposer implements Sg721Message {
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -180,7 +180,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -190,7 +190,7 @@ export class Sg721MessageComposer implements Sg721Message {
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -202,7 +202,7 @@ export class Sg721MessageComposer implements Sg721Message {
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -210,7 +210,7 @@ export class Sg721MessageComposer implements Sg721Message {
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -221,7 +221,7 @@ export class Sg721MessageComposer implements Sg721Message {
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -235,7 +235,7 @@ export class Sg721MessageComposer implements Sg721Message {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -249,7 +249,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_uri: tokenUri
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -257,7 +257,7 @@ export class Sg721MessageComposer implements Sg721Message {
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -268,7 +268,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/sg721/Sg721.message-composer.ts
+++ b/__output__/sg721/Sg721.message-composer.ts
@@ -108,7 +108,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -133,7 +133,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -158,7 +158,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -180,7 +180,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -202,7 +202,7 @@ export class Sg721MessageComposer implements Sg721Message {
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -221,7 +221,7 @@ export class Sg721MessageComposer implements Sg721Message {
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -249,7 +249,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_uri: tokenUri
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -268,7 +268,7 @@ export class Sg721MessageComposer implements Sg721Message {
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/vectis/factory-w-mutations/Factory.react-query.ts
+++ b/__output__/vectis/factory-w-mutations/Factory.react-query.ts
@@ -92,7 +92,7 @@ export interface FactoryUpdateAdminMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryUpdateAdminMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateAdminMutation>, "mutationFn">) {
@@ -102,9 +102,9 @@ export function useFactoryUpdateAdminMutation(options?: Omit<UseMutationOptions<
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateAdmin(msg, fee, memo, funds), options);
+  }) => client.updateAdmin(msg, fee, memo, _funds), options);
 }
 export interface FactoryUpdateGovecAddrMutation {
   client: FactoryClient;
@@ -114,7 +114,7 @@ export interface FactoryUpdateGovecAddrMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryUpdateGovecAddrMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateGovecAddrMutation>, "mutationFn">) {
@@ -124,9 +124,9 @@ export function useFactoryUpdateGovecAddrMutation(options?: Omit<UseMutationOpti
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateGovecAddr(msg, fee, memo, funds), options);
+  }) => client.updateGovecAddr(msg, fee, memo, _funds), options);
 }
 export interface FactoryUpdateWalletFeeMutation {
   client: FactoryClient;
@@ -136,7 +136,7 @@ export interface FactoryUpdateWalletFeeMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryUpdateWalletFeeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateWalletFeeMutation>, "mutationFn">) {
@@ -146,9 +146,9 @@ export function useFactoryUpdateWalletFeeMutation(options?: Omit<UseMutationOpti
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateWalletFee(msg, fee, memo, funds), options);
+  }) => client.updateWalletFee(msg, fee, memo, _funds), options);
 }
 export interface FactoryUpdateCodeIdMutation {
   client: FactoryClient;
@@ -159,7 +159,7 @@ export interface FactoryUpdateCodeIdMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryUpdateCodeIdMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateCodeIdMutation>, "mutationFn">) {
@@ -169,9 +169,9 @@ export function useFactoryUpdateCodeIdMutation(options?: Omit<UseMutationOptions
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateCodeId(msg, fee, memo, funds), options);
+  }) => client.updateCodeId(msg, fee, memo, _funds), options);
 }
 export interface FactoryMigrateWalletMutation {
   client: FactoryClient;
@@ -182,7 +182,7 @@ export interface FactoryMigrateWalletMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryMigrateWalletMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryMigrateWalletMutation>, "mutationFn">) {
@@ -192,9 +192,9 @@ export function useFactoryMigrateWalletMutation(options?: Omit<UseMutationOption
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.migrateWallet(msg, fee, memo, funds), options);
+  }) => client.migrateWallet(msg, fee, memo, _funds), options);
 }
 export interface FactoryUpdateProxyUserMutation {
   client: FactoryClient;
@@ -205,7 +205,7 @@ export interface FactoryUpdateProxyUserMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryUpdateProxyUserMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateProxyUserMutation>, "mutationFn">) {
@@ -215,9 +215,9 @@ export function useFactoryUpdateProxyUserMutation(options?: Omit<UseMutationOpti
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateProxyUser(msg, fee, memo, funds), options);
+  }) => client.updateProxyUser(msg, fee, memo, _funds), options);
 }
 export interface FactoryCreateWalletMutation {
   client: FactoryClient;
@@ -227,7 +227,7 @@ export interface FactoryCreateWalletMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useFactoryCreateWalletMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryCreateWalletMutation>, "mutationFn">) {
@@ -237,7 +237,7 @@ export function useFactoryCreateWalletMutation(options?: Omit<UseMutationOptions
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.createWallet(msg, fee, memo, funds), options);
+  }) => client.createWallet(msg, fee, memo, _funds), options);
 }

--- a/__output__/vectis/factory-w-mutations/Factory.react-query.ts
+++ b/__output__/vectis/factory-w-mutations/Factory.react-query.ts
@@ -92,7 +92,7 @@ export interface FactoryUpdateAdminMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryUpdateAdminMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateAdminMutation>, "mutationFn">) {
@@ -114,7 +114,7 @@ export interface FactoryUpdateGovecAddrMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryUpdateGovecAddrMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateGovecAddrMutation>, "mutationFn">) {
@@ -136,7 +136,7 @@ export interface FactoryUpdateWalletFeeMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryUpdateWalletFeeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateWalletFeeMutation>, "mutationFn">) {
@@ -159,7 +159,7 @@ export interface FactoryUpdateCodeIdMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryUpdateCodeIdMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateCodeIdMutation>, "mutationFn">) {
@@ -182,7 +182,7 @@ export interface FactoryMigrateWalletMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryMigrateWalletMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryMigrateWalletMutation>, "mutationFn">) {
@@ -205,7 +205,7 @@ export interface FactoryUpdateProxyUserMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryUpdateProxyUserMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryUpdateProxyUserMutation>, "mutationFn">) {
@@ -227,7 +227,7 @@ export interface FactoryCreateWalletMutation {
   args?: {
     fee?: number | StdFee | "auto";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useFactoryCreateWalletMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, FactoryCreateWalletMutation>, "mutationFn">) {

--- a/__output__/vectis/factory/Factory.client.ts
+++ b/__output__/vectis/factory/Factory.client.ts
@@ -114,43 +114,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -175,12 +175,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateProxyUser = async ({
     newUser,
@@ -188,13 +188,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -202,13 +202,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateCodeId = async ({
     newCodeId,
@@ -216,45 +216,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/vectis/factory/Factory.message-composer.ts
+++ b/__output__/vectis/factory/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMessageComposer implements FactoryMessage {
   sender: string;
@@ -73,7 +73,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -94,7 +94,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -116,7 +116,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -138,7 +138,7 @@ export class FactoryMessageComposer implements FactoryMessage {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -158,7 +158,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     newFee
   }: {
     newFee: Coin;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -177,7 +177,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -196,7 +196,7 @@ export class FactoryMessageComposer implements FactoryMessage {
     addr
   }: {
     addr: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/vectis/factory/Factory.message-composer.ts
+++ b/__output__/vectis/factory/Factory.message-composer.ts
@@ -84,7 +84,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             create_wallet_msg: createWalletMsg
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -106,7 +106,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             old_user: oldUser
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -128,7 +128,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             wallet_address: walletAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -150,7 +150,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             ty
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -169,7 +169,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             new_fee: newFee
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -188,7 +188,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -207,7 +207,7 @@ export class FactoryMessageComposer implements FactoryMessage {
             addr
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/vectis/govec/Govec.client.ts
+++ b/__output__/vectis/govec/Govec.client.ts
@@ -51,40 +51,40 @@ export interface GovecInterface extends GovecReadOnlyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class GovecClient extends GovecQueryClient implements GovecInterface {
   client: SigningCosmWasmClient;
@@ -110,61 +110,61 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGuardians = async ({
     guardians,
@@ -172,23 +172,23 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/vectis/govec/Govec.message-composer.ts
+++ b/__output__/vectis/govec/Govec.message-composer.ts
@@ -82,7 +82,7 @@ export class GovecMessageComposer implements GovecMessage {
             msgs
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -95,7 +95,7 @@ export class GovecMessageComposer implements GovecMessage {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -114,7 +114,7 @@ export class GovecMessageComposer implements GovecMessage {
             transaction
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -133,7 +133,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_user_address: newUserAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -152,7 +152,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_relayer_address: newRelayerAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class GovecMessageComposer implements GovecMessage {
             relayer_address: relayerAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -212,7 +212,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_label: newLabel
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/vectis/govec/Govec.message-composer.ts
+++ b/__output__/vectis/govec/Govec.message-composer.ts
@@ -15,40 +15,40 @@ export interface GovecMessage {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  revertFreezeStatus: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  revertFreezeStatus: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class GovecMessageComposer implements GovecMessage {
   sender: string;
@@ -71,7 +71,7 @@ export class GovecMessageComposer implements GovecMessage {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,11 +82,11 @@ export class GovecMessageComposer implements GovecMessage {
             msgs
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  revertFreezeStatus = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  revertFreezeStatus = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -95,7 +95,7 @@ export class GovecMessageComposer implements GovecMessage {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -103,7 +103,7 @@ export class GovecMessageComposer implements GovecMessage {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class GovecMessageComposer implements GovecMessage {
             transaction
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -122,7 +122,7 @@ export class GovecMessageComposer implements GovecMessage {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -133,7 +133,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_user_address: newUserAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -141,7 +141,7 @@ export class GovecMessageComposer implements GovecMessage {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,7 +152,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_relayer_address: newRelayerAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -160,7 +160,7 @@ export class GovecMessageComposer implements GovecMessage {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class GovecMessageComposer implements GovecMessage {
             relayer_address: relayerAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class GovecMessageComposer implements GovecMessage {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -201,7 +201,7 @@ export class GovecMessageComposer implements GovecMessage {
     newLabel
   }: {
     newLabel: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -212,7 +212,7 @@ export class GovecMessageComposer implements GovecMessage {
             new_label: newLabel
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/__output__/vectis/proxy/Proxy.client.ts
+++ b/__output__/vectis/proxy/Proxy.client.ts
@@ -51,40 +51,40 @@ export interface ProxyInterface extends ProxyReadOnlyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   client: SigningCosmWasmClient;
@@ -110,61 +110,61 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGuardians = async ({
     guardians,
@@ -172,23 +172,23 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }

--- a/__output__/vectis/proxy/Proxy.message-composer.ts
+++ b/__output__/vectis/proxy/Proxy.message-composer.ts
@@ -82,7 +82,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             msgs
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -95,7 +95,7 @@ export class ProxyMessageComposer implements ProxyMessage {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -114,7 +114,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             transaction
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -133,7 +133,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_user_address: newUserAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -152,7 +152,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_relayer_address: newRelayerAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -171,7 +171,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             relayer_address: relayerAddress
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -193,7 +193,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -212,7 +212,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_label: newLabel
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/__output__/vectis/proxy/Proxy.message-composer.ts
+++ b/__output__/vectis/proxy/Proxy.message-composer.ts
@@ -15,40 +15,40 @@ export interface ProxyMessage {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  revertFreezeStatus: (funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  revertFreezeStatus: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class ProxyMessageComposer implements ProxyMessage {
   sender: string;
@@ -71,7 +71,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,11 +82,11 @@ export class ProxyMessageComposer implements ProxyMessage {
             msgs
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  revertFreezeStatus = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  revertFreezeStatus = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -95,7 +95,7 @@ export class ProxyMessageComposer implements ProxyMessage {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -103,7 +103,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -114,7 +114,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             transaction
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -122,7 +122,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -133,7 +133,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_user_address: newUserAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -141,7 +141,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,7 +152,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_relayer_address: newRelayerAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -160,7 +160,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -171,7 +171,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             relayer_address: relayerAddress
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -181,7 +181,7 @@ export class ProxyMessageComposer implements ProxyMessage {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -193,7 +193,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -201,7 +201,7 @@ export class ProxyMessageComposer implements ProxyMessage {
     newLabel
   }: {
     newLabel: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -212,7 +212,7 @@ export class ProxyMessageComposer implements ProxyMessage {
             new_label: newLabel
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.account-nfts.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.account-nfts.spec.ts.snap
@@ -27,10 +27,10 @@ exports[`execute classes array types 1`] = `
     this.minter = this.minter.bind(this);
   }
 
-  proposedNewOwner = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  proposedNewOwner = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proposed_new_owner: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allowedVaults = async ({
     limit,
@@ -38,13 +38,13 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allowed_vaults: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allDebtShares = async ({
     limit,
@@ -52,18 +52,18 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_debt_shares: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  allPreviousOwners = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  allPreviousOwners = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_previous_owners: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   ownerOf = async ({
     includeExpired,
@@ -71,13 +71,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       owner_of: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approval = async ({
     includeExpired,
@@ -87,14 +87,14 @@ exports[`execute classes array types 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approval: {
         include_expired: includeExpired,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approvals = async ({
     includeExpired,
@@ -102,13 +102,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approvals: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allOperators = async ({
     includeExpired,
@@ -120,7 +120,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_operators: {
         include_expired: includeExpired,
@@ -128,28 +128,28 @@ exports[`execute classes array types 1`] = `
         owner,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  numTokens = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  numTokens = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       num_tokens: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  contractInfo = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  contractInfo = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       contract_info: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   nftInfo = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       nft_info: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allNftInfo = async ({
     includeExpired,
@@ -157,13 +157,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_nft_info: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   tokens = async ({
     limit,
@@ -173,14 +173,14 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       tokens: {
         limit,
         owner,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   allTokens = async ({
     limit,
@@ -188,18 +188,18 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_tokens: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  minter = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  minter = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       minter: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -208,29 +208,29 @@ exports[`execute interfaces no extends 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  proposedNewOwner: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  proposedNewOwner: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allowedVaults: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allDebtShares: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  allPreviousOwners: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  allPreviousOwners: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   ownerOf: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approval: ({
     includeExpired,
     spender,
@@ -239,14 +239,14 @@ exports[`execute interfaces no extends 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approvals: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allOperators: ({
     includeExpired,
     limit,
@@ -257,21 +257,21 @@ exports[`execute interfaces no extends 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  numTokens: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  contractInfo: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  numTokens: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  contractInfo: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   nftInfo: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allNftInfo: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   tokens: ({
     limit,
     owner,
@@ -280,15 +280,15 @@ exports[`execute interfaces no extends 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   allTokens: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  minter: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  minter: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.arrays-ref.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.arrays-ref.spec.ts.snap
@@ -32,13 +32,13 @@ exports[`execute classes array types 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
         creditor
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   editEdge = async ({
     amount,
@@ -48,36 +48,36 @@ exports[`execute classes array types 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
         creditor,
         edge_id: edgeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraph = async ({
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraphSimplified = async ({
     graph,
@@ -85,13 +85,13 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   editGraphSimplified = async ({
     graph,
@@ -99,89 +99,89 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateEdges = async ({
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  findSavings = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   findSavingsInAGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  reset = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   saveNetworkToFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraphFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   applySetOffFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -196,7 +196,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   editEdge: ({
     amount,
     creditor,
@@ -205,63 +205,63 @@ exports[`execute interfaces no extends 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraph: ({
     graph
   }: {
     graph: Edge[];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   editGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateEdges: ({
     edges
   }: {
     edges: number[][];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  findSavings: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  findSavings: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   findSavingsInAGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  reset: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  reset: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   saveNetworkToFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraphFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   applySetOffFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.arrays.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.arrays.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,
@@ -34,7 +34,7 @@ exports[`execute classes array types 1`] = `
         nested,
         supernested
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -55,7 +55,7 @@ exports[`execute interfaces no extends 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.cw-named-groups.test.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.cw-named-groups.test.ts.snap
@@ -23,36 +23,36 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -69,17 +69,17 @@ exports[`execute interfaces no extends 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
@@ -29,14 +29,14 @@ exports[`execute classes array types 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   vote = async ({
     proposalId,
@@ -44,35 +44,35 @@ exports[`execute classes array types 1`] = `
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     allowRevoting,
@@ -90,7 +90,7 @@ exports[`execute classes array types 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -101,51 +101,51 @@ exports[`execute classes array types 1`] = `
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -162,24 +162,24 @@ exports[`execute interfaces no extends 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -196,27 +196,27 @@ exports[`execute interfaces no extends 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-101.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-101.spec.ts.snap
@@ -8,8 +8,8 @@ exports[`execute interfaces no extends 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateOwnership: (action: Action, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  updateOwnership: (action: Action, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 
@@ -31,17 +31,17 @@ exports[`ownership client with tuple 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_factory: {
         new_factory: newFactory
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  updateOwnership = async (action: Action, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateOwnership = async (action: Action, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_ownership: action
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-71.test.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-71.test.ts.snap
@@ -30,14 +30,14 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateConfig = async ({
     feeCollector,
@@ -47,14 +47,14 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         fee_collector: feeCollector,
         generator_address: generatorAddress,
         lp_token_code_id: lpTokenCodeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updatePoolConfig = async ({
     isDisabled,
@@ -64,25 +64,25 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_pool_config: {
         is_disabled: isDisabled,
         new_fee_info: newFeeInfo,
         pool_type: poolType
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addToRegistery = async ({
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_to_registery: {
         new_pool_config: newPoolConfig
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createPoolInstance = async ({
     assetInfos,
@@ -96,7 +96,7 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_pool_instance: {
         asset_infos: assetInfos,
@@ -105,7 +105,7 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
         lp_token_symbol: lpTokenSymbol,
         pool_type: poolType
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   joinPool = async ({
     assets,
@@ -121,7 +121,7 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       join_pool: {
         assets,
@@ -131,7 +131,7 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
         recipient,
         slippage_tolerance: slippageTolerance
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   swap = async ({
     recipient,
@@ -139,13 +139,13 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       swap: {
         recipient,
         swap_request: swapRequest
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   proposeNewOwner = async ({
     expiresIn,
@@ -153,23 +153,23 @@ exports[`execute class /issues/71/execute_msg.json 1`] = `
   }: {
     expiresIn: number;
     owner: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         expires_in: expiresIn,
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  dropOwnershipProposal = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  dropOwnershipProposal = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       drop_ownership_proposal: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  claimOwnership = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  claimOwnership = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       claim_ownership: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -186,7 +186,7 @@ exports[`execute interface /issues/71/execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     feeCollector,
     generatorAddress,
@@ -195,7 +195,7 @@ exports[`execute interface /issues/71/execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updatePoolConfig: ({
     isDisabled,
     newFeeInfo,
@@ -204,12 +204,12 @@ exports[`execute interface /issues/71/execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addToRegistery: ({
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createPoolInstance: ({
     assetInfos,
     initParams,
@@ -222,7 +222,7 @@ exports[`execute interface /issues/71/execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   joinPool: ({
     assets,
     autoStake,
@@ -237,23 +237,23 @@ exports[`execute interface /issues/71/execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   swap: ({
     recipient,
     swapRequest
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   proposeNewOwner: ({
     expiresIn,
     owner
   }: {
     expiresIn: number;
     owner: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  dropOwnershipProposal: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  claimOwnership: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  dropOwnershipProposal: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  claimOwnership: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-98.test.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issue-98.test.ts.snap
@@ -15,10 +15,10 @@ exports[`execute classes array types 1`] = `
     this.getPluginById = this.getPluginById.bind(this);
   }
 
-  getConfig = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  getConfig = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_config: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getPlugins = async ({
     limit,
@@ -26,24 +26,24 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugins: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getPluginById = async ({
     id
   }: {
     id: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugin_by_id: {
         id
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -52,19 +52,19 @@ exports[`execute interfaces no extends 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  getConfig: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  getConfig: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getPlugins: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getPluginById: ({
     id
   }: {
     id: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issues.test.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.issues.test.ts.snap
@@ -77,13 +77,13 @@ exports[`execute class /issues/55/execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
         creditor
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   editEdge = async ({
     amount,
@@ -93,36 +93,36 @@ exports[`execute class /issues/55/execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
         creditor,
         edge_id: edgeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraph = async ({
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraphSimplified = async ({
     graph,
@@ -130,13 +130,13 @@ exports[`execute class /issues/55/execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   editGraphSimplified = async ({
     graph,
@@ -144,89 +144,89 @@ exports[`execute class /issues/55/execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateEdges = async ({
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  findSavings = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   findSavingsInAGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  reset = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   saveNetworkToFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   createGraphFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   applySetOffFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -285,113 +285,113 @@ exports[`execute class /issues/55/query_msg.json 1`] = `
     this.getTotalDebt = this.getTotalDebt.bind(this);
   }
 
-  getDenom = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  getDenom = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_denom: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  getOwner = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  getOwner = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_owner: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  allEdges = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  allEdges = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_edges: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   oneEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   oneBatch = async ({
     batchId
   }: {
     batchId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_batch: {
         batch_id: batchId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   oneGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getEdgesByAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_by_address: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getEdgesAsCounterparty = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_as_counterparty: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getTotalDebtPerAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_per_address: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getTotalCreditPerAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_credit_per_address: {
         address
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   getTotalDebtByGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_by_graph: {
         graph_id: graphId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  getTotalDebt = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  getTotalDebt = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -427,7 +427,7 @@ exports[`execute interface /issues/55/execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   editEdge: ({
     amount,
     creditor,
@@ -436,63 +436,63 @@ exports[`execute interface /issues/55/execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraph: ({
     graph
   }: {
     graph: Edge[];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   editGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateEdges: ({
     edges
   }: {
     edges: number[][];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  findSavings: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  findSavings: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   findSavingsInAGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  reset: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  reset: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   saveNetworkToFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   createGraphFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   applySetOffFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 
@@ -514,50 +514,50 @@ exports[`execute interface /issues/55/query_msg.json 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  getDenom: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  getOwner: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  allEdges: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  getDenom: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  getOwner: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  allEdges: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   oneEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   oneBatch: ({
     batchId
   }: {
     batchId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   oneGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getEdgesByAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getEdgesAsCounterparty: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getTotalDebtPerAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getTotalCreditPerAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   getTotalDebtByGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  getTotalDebt: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  getTotalDebt: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.overrides.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.overrides.spec.ts.snap
@@ -27,13 +27,13 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -43,14 +43,14 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -60,14 +60,14 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -75,13 +75,13 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -89,24 +89,24 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -118,7 +118,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -126,18 +126,18 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -168,13 +168,13 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -184,14 +184,14 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -201,14 +201,14 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -216,13 +216,13 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -230,24 +230,24 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -259,7 +259,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -267,18 +267,18 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -310,13 +310,13 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -326,14 +326,14 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -343,14 +343,14 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -358,13 +358,13 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -372,24 +372,24 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -401,7 +401,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -409,18 +409,18 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -452,13 +452,13 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -468,14 +468,14 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -485,14 +485,14 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -500,13 +500,13 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -514,24 +514,24 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -543,7 +543,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -551,18 +551,18 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -593,13 +593,13 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -609,14 +609,14 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -626,14 +626,14 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -641,13 +641,13 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -655,24 +655,24 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -684,7 +684,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -692,18 +692,18 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.sg721.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.sg721.spec.ts.snap
@@ -26,13 +26,13 @@ exports[`execute classes array types 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -42,14 +42,14 @@ exports[`execute classes array types 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -59,14 +59,14 @@ exports[`execute classes array types 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -74,13 +74,13 @@ exports[`execute classes array types 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -88,24 +88,24 @@ exports[`execute classes array types 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -117,7 +117,7 @@ exports[`execute classes array types 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -125,18 +125,18 @@ exports[`execute classes array types 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -151,7 +151,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -160,7 +160,7 @@ exports[`execute interfaces no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -169,26 +169,26 @@ exports[`execute interfaces no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -199,12 +199,12 @@ exports[`execute interfaces no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.spec.ts.snap
@@ -63,13 +63,13 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -79,14 +79,14 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -96,14 +96,14 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -111,13 +111,13 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -125,24 +125,24 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -154,7 +154,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -162,18 +162,18 @@ exports[`execute classes 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -201,36 +201,36 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -261,13 +261,13 @@ exports[`execute classes no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   sendNft = async ({
     contract,
@@ -277,14 +277,14 @@ exports[`execute classes no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approve = async ({
     expires,
@@ -294,14 +294,14 @@ exports[`execute classes no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revoke = async ({
     spender,
@@ -309,13 +309,13 @@ exports[`execute classes no extends 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   approveAll = async ({
     expires,
@@ -323,24 +323,24 @@ exports[`execute classes no extends 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   mint = async ({
     extension,
@@ -352,7 +352,7 @@ exports[`execute classes no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -360,18 +360,18 @@ exports[`execute classes no extends 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -386,7 +386,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -395,7 +395,7 @@ exports[`execute interfaces no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -404,26 +404,26 @@ exports[`execute interfaces no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -434,12 +434,12 @@ exports[`execute interfaces no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.vectis.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.vectis.spec.ts.snap
@@ -32,61 +32,61 @@ exports[`execute classes array types 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
-  revertFreezeStatus = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateGuardians = async ({
     guardians,
@@ -94,24 +94,24 @@ exports[`execute classes array types 1`] = `
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;
@@ -124,40 +124,40 @@ exports[`execute interfaces no extends 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | \\"auto\\", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee?: number | StdFee | \\"auto\\", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.wager.spec.ts.snap
+++ b/packages/wasm-ast-types/src/client/test/__snapshots__/ts-client.wager.spec.ts.snap
@@ -22,12 +22,12 @@ exports[`execute classes 1`] = `
     params
   }: {
     params: ParamInfo;
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         params
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   setWinner = async ({
     currentPrices,
@@ -37,14 +37,14 @@ exports[`execute classes 1`] = `
     currentPrices: number[][];
     prevPrices: number[][];
     wagerKey: Addr[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_winner: {
         current_prices: currentPrices,
         prev_prices: prevPrices,
         wager_key: wagerKey
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   wager = async ({
     againstCurrencies,
@@ -56,7 +56,7 @@ exports[`execute classes 1`] = `
     currency: Currency;
     expiry: number;
     token: Addr[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       wager: {
         against_currencies: againstCurrencies,
@@ -64,18 +64,18 @@ exports[`execute classes 1`] = `
         expiry,
         token
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
   cancel = async ({
     token
   }: {
     token: Addr[][];
-  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cancel: {
         token
       }
-    }, fee, memo, funds);
+    }, fee, memo, _funds);
   };
 }"
 `;

--- a/packages/wasm-ast-types/src/message-composer/__snapshots__/message-composer.spec.ts.snap
+++ b/packages/wasm-ast-types/src/message-composer/__snapshots__/message-composer.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`createMessageComposerInterface 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -19,7 +19,7 @@ exports[`createMessageComposerInterface 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -28,26 +28,26 @@ exports[`createMessageComposerInterface 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     extension,
     owner,
@@ -58,12 +58,12 @@ exports[`createMessageComposerInterface 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }"
 `;
 
@@ -91,7 +91,7 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -103,7 +103,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -115,7 +115,7 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -128,7 +128,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -140,7 +140,7 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -153,7 +153,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -163,7 +163,7 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -175,7 +175,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -185,7 +185,7 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -197,7 +197,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -205,7 +205,7 @@ exports[`execute classes 1`] = `
     operator
   }: {
     operator: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -216,7 +216,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -230,7 +230,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -244,7 +244,7 @@ exports[`execute classes 1`] = `
             token_uri: tokenUri
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -252,7 +252,7 @@ exports[`execute classes 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -263,7 +263,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -286,7 +286,7 @@ exports[`ownershipClass 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -297,11 +297,11 @@ exports[`ownershipClass 1`] = `
             new_factory: newFactory
           }
         })),
-        funds
+        _funds: funds
       })
     };
   };
-  updateOwnership = (action: Action, funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateOwnership = (action: Action, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: \\"/cosmwasm.wasm.v1.MsgExecuteContract\\",
       value: MsgExecuteContract.fromPartial({
@@ -310,7 +310,7 @@ exports[`ownershipClass 1`] = `
         msg: toUtf8(JSON.stringify({
           update_ownership: action
         })),
-        funds
+        _funds: funds
       })
     };
   };
@@ -325,7 +325,7 @@ exports[`ownershipInterface 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateOwnership: (action: Action, funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateOwnership: (action: Action, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
 }"
 `;

--- a/packages/wasm-ast-types/src/message-composer/__snapshots__/message-composer.spec.ts.snap
+++ b/packages/wasm-ast-types/src/message-composer/__snapshots__/message-composer.spec.ts.snap
@@ -103,7 +103,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -128,7 +128,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -153,7 +153,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -175,7 +175,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -197,7 +197,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -216,7 +216,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -244,7 +244,7 @@ exports[`execute classes 1`] = `
             token_uri: tokenUri
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -263,7 +263,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -297,7 +297,7 @@ exports[`ownershipClass 1`] = `
             new_factory: newFactory
           }
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };
@@ -310,7 +310,7 @@ exports[`ownershipClass 1`] = `
         msg: toUtf8(JSON.stringify({
           update_ownership: action
         })),
-        _funds: funds
+        funds: _funds
       })
     };
   };

--- a/packages/wasm-ast-types/src/message-composer/message-composer.ts
+++ b/packages/wasm-ast-types/src/message-composer/message-composer.ts
@@ -1,26 +1,19 @@
 import * as t from '@babel/types';
+import { Expression } from '@babel/types';
 import { camel } from 'case';
 import {
+  arrowFunctionExpression,
   bindMethod,
-  typedIdentifier,
   classDeclaration,
   classProperty,
-  arrowFunctionExpression,
-  getMessageProperties
+  getMessageProperties,
+  OPTIONAL_FUNDS_PARAM,
+  typedIdentifier
 } from '../utils';
-import { ExecuteMsg } from '../types';
+import { ExecuteMsg, JSONSchema } from '../types';
 import { createTypedObjectParams } from '../utils/types';
-import { JSONSchema } from '../types';
 import { RenderContext } from '../context';
-import { identifier } from '../utils/babel';
 import { getWasmMethodArgs } from '../client/client';
-import { Expression } from '@babel/types';
-
-const OPTIONAL_FUNDS = identifier(
-  '_funds',
-  t.tsTypeAnnotation(t.tsArrayType(t.tsTypeReference(t.identifier('Coin')))),
-  true
-);
 
 const createWasmExecMethodMessageComposer = (
   context: RenderContext,
@@ -50,7 +43,7 @@ const createWasmExecMethodMessageComposer = (
     actionValue = t.objectExpression(args);
   }
 
-  const constantParams = [OPTIONAL_FUNDS];
+  const constantParams = [OPTIONAL_FUNDS_PARAM];
 
   return t.classProperty(
     t.identifier(methodName),
@@ -250,7 +243,7 @@ const createPropertyFunctionWithObjectParamsForMessageComposer = (
   jsonschema: JSONSchema
 ) => {
   const obj = createTypedObjectParams(context, jsonschema);
-  const fixedParams = [OPTIONAL_FUNDS];
+  const fixedParams = [OPTIONAL_FUNDS_PARAM];
   const func = {
     type: 'TSFunctionType',
     typeAnnotation: t.tsTypeAnnotation(

--- a/packages/wasm-ast-types/src/message-composer/message-composer.ts
+++ b/packages/wasm-ast-types/src/message-composer/message-composer.ts
@@ -1,13 +1,13 @@
 import * as t from '@babel/types';
 import { camel } from 'case';
 import {
-    bindMethod,
-    typedIdentifier,
-    classDeclaration,
-    classProperty,
-    arrowFunctionExpression,
-    getMessageProperties
-} from '../utils'
+  bindMethod,
+  typedIdentifier,
+  classDeclaration,
+  classProperty,
+  arrowFunctionExpression,
+  getMessageProperties
+} from '../utils';
 import { ExecuteMsg } from '../types';
 import { createTypedObjectParams } from '../utils/types';
 import { JSONSchema } from '../types';
@@ -16,298 +16,254 @@ import { identifier } from '../utils/babel';
 import { getWasmMethodArgs } from '../client/client';
 import { Expression } from '@babel/types';
 
+const OPTIONAL_FUNDS = identifier(
+  '_funds',
+  t.tsTypeAnnotation(t.tsArrayType(t.tsTypeReference(t.identifier('Coin')))),
+  true
+);
+
 const createWasmExecMethodMessageComposer = (
-    context: RenderContext,
-    jsonschema: any
+  context: RenderContext,
+  jsonschema: any
 ) => {
+  context.addUtil('Coin');
+  context.addUtil('MsgExecuteContractEncodeObject');
+  context.addUtil('MsgExecuteContract');
+  context.addUtil('toUtf8');
 
-    context.addUtil('Coin');
-    context.addUtil('MsgExecuteContractEncodeObject');
-    context.addUtil('MsgExecuteContract');
-    context.addUtil('toUtf8');
-
-    const underscoreName = Object.keys(jsonschema.properties)[0];
-    const methodName = camel(underscoreName);
-    const param = createTypedObjectParams(context, jsonschema.properties[underscoreName]);
-    const args = getWasmMethodArgs(
-        context,
-        jsonschema.properties[underscoreName]
-    );
+  const underscoreName = Object.keys(jsonschema.properties)[0];
+  const methodName = camel(underscoreName);
+  const param = createTypedObjectParams(
+    context,
+    jsonschema.properties[underscoreName]
+  );
+  const args = getWasmMethodArgs(
+    context,
+    jsonschema.properties[underscoreName]
+  );
 
   // what the underscore named property in the message is assigned to
-  let actionValue: Expression
+  let actionValue: Expression;
   if (param?.type === 'Identifier') {
     actionValue = t.identifier(param.name);
   } else {
-    actionValue = t.objectExpression(args)
+    actionValue = t.objectExpression(args);
   }
 
-    const constantParams = [
-        identifier('funds', t.tsTypeAnnotation(
-            t.tsArrayType(
-                t.tsTypeReference(
-                    t.identifier('Coin')
-                )
-            )
-        ), true)
-    ];
+  const constantParams = [OPTIONAL_FUNDS];
 
-    return t.classProperty(
-        t.identifier(methodName),
-        arrowFunctionExpression(
-            param ? [
-                // props
-                param,
-                ...constantParams
-            ] : constantParams,
-            t.blockStatement(
+  return t.classProperty(
+    t.identifier(methodName),
+    arrowFunctionExpression(
+      param
+        ? [
+            // props
+            param,
+            ...constantParams
+          ]
+        : constantParams,
+      t.blockStatement([
+        t.returnStatement(
+          t.objectExpression([
+            t.objectProperty(
+              t.identifier('typeUrl'),
+              t.stringLiteral('/cosmwasm.wasm.v1.MsgExecuteContract')
+            ),
+            t.objectProperty(
+              t.identifier('value'),
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier('MsgExecuteContract'),
+                  t.identifier('fromPartial')
+                ),
                 [
-                    t.returnStatement(
-
-                        t.objectExpression([
-                            t.objectProperty(
-                                t.identifier('typeUrl'),
-                                t.stringLiteral('/cosmwasm.wasm.v1.MsgExecuteContract')
-                            ),
-                            t.objectProperty(
-                                t.identifier('value'),
-                                t.callExpression(
-                                    t.memberExpression(
-                                        t.identifier('MsgExecuteContract'),
-                                        t.identifier('fromPartial')
-                                    ),
-                                    [
-                                        t.objectExpression([
-                                            t.objectProperty(
-                                                t.identifier('sender'),
-                                                t.memberExpression(
-                                                    t.thisExpression(),
-                                                    t.identifier('sender')
-                                                )
-                                            ),
-                                            t.objectProperty(
-                                                t.identifier('contract'),
-                                                t.memberExpression(
-                                                    t.thisExpression(),
-                                                    t.identifier('contractAddress')
-                                                )
-                                            ),
-                                            t.objectProperty(
-                                                t.identifier('msg'),
-                                                t.callExpression(
-                                                    t.identifier('toUtf8'),
-                                                    [
-                                                        t.callExpression(
-                                                            t.memberExpression(
-                                                                t.identifier('JSON'),
-                                                                t.identifier('stringify')
-                                                            ),
-                                                            [
-                                                                t.objectExpression(
-                                                                    [
-                                                                        t.objectProperty(
-                                                                            t.identifier(underscoreName), actionValue
-                                                                        )
-                                                                    ]
-
-                                                                )
-                                                            ]
-                                                        )
-                                                    ]
-                                                )
-                                            ),
-                                            t.objectProperty(
-                                                t.identifier('funds'),
-                                                t.identifier('funds'),
-                                                false,
-                                                true
-                                            ),
-                                        ])
-                                    ]
-                                )
-                            )
-                        ])
+                  t.objectExpression([
+                    t.objectProperty(
+                      t.identifier('sender'),
+                      t.memberExpression(
+                        t.thisExpression(),
+                        t.identifier('sender')
+                      )
+                    ),
+                    t.objectProperty(
+                      t.identifier('contract'),
+                      t.memberExpression(
+                        t.thisExpression(),
+                        t.identifier('contractAddress')
+                      )
+                    ),
+                    t.objectProperty(
+                      t.identifier('msg'),
+                      t.callExpression(t.identifier('toUtf8'), [
+                        t.callExpression(
+                          t.memberExpression(
+                            t.identifier('JSON'),
+                            t.identifier('stringify')
+                          ),
+                          [
+                            t.objectExpression([
+                              t.objectProperty(
+                                t.identifier(underscoreName),
+                                actionValue
+                              )
+                            ])
+                          ]
+                        )
+                      ])
+                    ),
+                    t.objectProperty(
+                      t.identifier('_funds'),
+                      t.identifier('funds')
                     )
+                  ])
                 ]
-            ),
-            // return type
-            t.tsTypeAnnotation(
-                t.tsTypeReference(
-                    t.identifier('MsgExecuteContractEncodeObject')
-                )
-            ),
-            false
+              )
+            )
+          ])
         )
-    );
-
-}
+      ]),
+      // return type
+      t.tsTypeAnnotation(
+        t.tsTypeReference(t.identifier('MsgExecuteContractEncodeObject'))
+      ),
+      false
+    )
+  );
+};
 
 export const createMessageComposerClass = (
-    context: RenderContext,
-    className: string,
-    implementsClassName: string,
-    execMsg: ExecuteMsg
+  context: RenderContext,
+  className: string,
+  implementsClassName: string,
+  execMsg: ExecuteMsg
 ) => {
+  const propertyNames = getMessageProperties(execMsg)
+    .map((method) => Object.keys(method.properties)?.[0])
+    .filter(Boolean);
 
-    const propertyNames = getMessageProperties(execMsg)
-        .map(method => Object.keys(method.properties)?.[0])
-        .filter(Boolean);
+  const bindings = propertyNames.map(camel).map(bindMethod);
 
-    const bindings = propertyNames
-        .map(camel)
-        .map(bindMethod);
+  const methods = getMessageProperties(execMsg).map((schema) => {
+    return createWasmExecMethodMessageComposer(context, schema);
+  });
 
-    const methods = getMessageProperties(execMsg)
-        .map(schema => {
-            return createWasmExecMethodMessageComposer(context, schema)
-        });
+  const blockStmt = [];
 
-    const blockStmt = [];
+  [].push.apply(blockStmt, [
+    t.expressionStatement(
+      t.assignmentExpression(
+        '=',
+        t.memberExpression(t.thisExpression(), t.identifier('sender')),
+        t.identifier('sender')
+      )
+    ),
+    t.expressionStatement(
+      t.assignmentExpression(
+        '=',
+        t.memberExpression(t.thisExpression(), t.identifier('contractAddress')),
+        t.identifier('contractAddress')
+      )
+    ),
+    ...bindings
+  ]);
 
-    [].push.apply(blockStmt, [
-        t.expressionStatement(
-            t.assignmentExpression(
-                '=',
-                t.memberExpression(
-                    t.thisExpression(),
-                    t.identifier('sender')
-                ),
-                t.identifier('sender')
-            )
+  return t.exportNamedDeclaration(
+    classDeclaration(
+      className,
+      [
+        // sender
+        classProperty('sender', t.tsTypeAnnotation(t.tsStringKeyword())),
+
+        // contractAddress
+        classProperty(
+          'contractAddress',
+          t.tsTypeAnnotation(t.tsStringKeyword())
         ),
-        t.expressionStatement(
-            t.assignmentExpression(
-                '=',
-                t.memberExpression(
-                    t.thisExpression(),
-                    t.identifier('contractAddress')
-                ),
-                t.identifier('contractAddress')
+
+        // constructor
+        t.classMethod(
+          'constructor',
+          t.identifier('constructor'),
+          [
+            typedIdentifier('sender', t.tsTypeAnnotation(t.tsStringKeyword())),
+            typedIdentifier(
+              'contractAddress',
+              t.tsTypeAnnotation(t.tsStringKeyword())
             )
+          ],
+          t.blockStatement(blockStmt)
         ),
-        ...bindings
-    ]);
-
-    return t.exportNamedDeclaration(
-        classDeclaration(className,
-            [
-                // sender
-                classProperty('sender', t.tsTypeAnnotation(
-                    t.tsStringKeyword()
-                )),
-
-                // contractAddress
-                classProperty('contractAddress', t.tsTypeAnnotation(
-                    t.tsStringKeyword()
-                )),
-
-                // constructor
-                t.classMethod('constructor',
-                    t.identifier('constructor'),
-                    [
-                        typedIdentifier('sender', t.tsTypeAnnotation(t.tsStringKeyword())),
-                        typedIdentifier('contractAddress', t.tsTypeAnnotation(t.tsStringKeyword()))
-                    ],
-                    t.blockStatement(
-                        blockStmt
-                    )),
-                ...methods
-            ],
-            [
-                t.tSExpressionWithTypeArguments(
-                    t.identifier(implementsClassName)
-                )
-            ],
-            null
-        )
-    );
-}
+        ...methods
+      ],
+      [t.tSExpressionWithTypeArguments(t.identifier(implementsClassName))],
+      null
+    )
+  );
+};
 
 export const createMessageComposerInterface = (
-    context: RenderContext,
-    className: string,
-    execMsg: ExecuteMsg
+  context: RenderContext,
+  className: string,
+  execMsg: ExecuteMsg
 ) => {
-
-    const methods = getMessageProperties(execMsg)
-        .map(jsonschema => {
-            const underscoreName = Object.keys(jsonschema.properties)[0];
-            const methodName = camel(underscoreName);
-            return createPropertyFunctionWithObjectParamsForMessageComposer(
-                context,
-                methodName,
-                'MsgExecuteContractEncodeObject',
-                jsonschema.properties[underscoreName]
-            );
-        });
-
-    const extendsAst = [];
-
-    return t.exportNamedDeclaration(
-        t.tsInterfaceDeclaration(
-            t.identifier(className),
-            null,
-            extendsAst,
-            t.tSInterfaceBody(
-                [
-
-                    // contract address
-                    t.tSPropertySignature(
-                        t.identifier('contractAddress'),
-                        t.tsTypeAnnotation(
-                            t.tsStringKeyword()
-                        )
-                    ),
-
-                    // contract address
-                    t.tSPropertySignature(
-                        t.identifier('sender'),
-                        t.tsTypeAnnotation(
-                            t.tsStringKeyword()
-                        )
-                    ),
-
-                    ...methods,
-                ]
-            )
-        )
+  const methods = getMessageProperties(execMsg).map((jsonschema) => {
+    const underscoreName = Object.keys(jsonschema.properties)[0];
+    const methodName = camel(underscoreName);
+    return createPropertyFunctionWithObjectParamsForMessageComposer(
+      context,
+      methodName,
+      'MsgExecuteContractEncodeObject',
+      jsonschema.properties[underscoreName]
     );
+  });
+
+  const extendsAst = [];
+
+  return t.exportNamedDeclaration(
+    t.tsInterfaceDeclaration(
+      t.identifier(className),
+      null,
+      extendsAst,
+      t.tSInterfaceBody([
+        // contract address
+        t.tSPropertySignature(
+          t.identifier('contractAddress'),
+          t.tsTypeAnnotation(t.tsStringKeyword())
+        ),
+
+        // contract address
+        t.tSPropertySignature(
+          t.identifier('sender'),
+          t.tsTypeAnnotation(t.tsStringKeyword())
+        ),
+
+        ...methods
+      ])
+    )
+  );
 };
 
 const createPropertyFunctionWithObjectParamsForMessageComposer = (
-    context: RenderContext,
-    methodName: string,
-    responseType: string,
-    jsonschema: JSONSchema
+  context: RenderContext,
+  methodName: string,
+  responseType: string,
+  jsonschema: JSONSchema
 ) => {
-    const obj = createTypedObjectParams(context, jsonschema);
-    const fixedParams = [
-        identifier('funds', t.tsTypeAnnotation(
-            t.tsArrayType(
-                t.tsTypeReference(
-                    t.identifier('Coin')
-                )
-            )
-        ), true)
-    ];
-    const func = {
-        type: 'TSFunctionType',
-        typeAnnotation: t.tsTypeAnnotation(t.tsTypeReference(
-            t.identifier(responseType)
-        )),
-        parameters: obj ? [
-            obj,
-            ...fixedParams
+  const obj = createTypedObjectParams(context, jsonschema);
+  const fixedParams = [OPTIONAL_FUNDS];
+  const func = {
+    type: 'TSFunctionType',
+    typeAnnotation: t.tsTypeAnnotation(
+      t.tsTypeReference(t.identifier(responseType))
+    ),
+    parameters: obj ? [obj, ...fixedParams] : fixedParams
+  };
 
-        ] : fixedParams
-    }
-
-    return t.tSPropertySignature(
-        t.identifier(methodName),
-        t.tsTypeAnnotation(
-            // @ts-ignore:next-line
-            func
-        )
-    );
+  return t.tSPropertySignature(
+    t.identifier(methodName),
+    t.tsTypeAnnotation(
+      // @ts-ignore:next-line
+      func
+    )
+  );
 };
-

--- a/packages/wasm-ast-types/src/message-composer/message-composer.ts
+++ b/packages/wasm-ast-types/src/message-composer/message-composer.ts
@@ -105,8 +105,8 @@ const createWasmExecMethodMessageComposer = (
                       ])
                     ),
                     t.objectProperty(
-                      t.identifier('_funds'),
-                      t.identifier('funds')
+                      t.identifier('funds'),
+                      t.identifier('_funds')
                     )
                   ])
                 ]

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -1133,7 +1133,7 @@ exports[`createReactQueryHooks 6`] = `
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721BurnMutation>, \\"mutationFn\\">) {
@@ -1143,9 +1143,9 @@ export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteRe
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.burn(msg, fee, memo, funds), options);
+  }) => client.burn(msg, fee, memo, _funds), options);
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
@@ -1158,7 +1158,7 @@ export interface Sg721MintMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721MintMutation>, \\"mutationFn\\">) {
@@ -1168,9 +1168,9 @@ export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteRe
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.mint(msg, fee, memo, funds), options);
+  }) => client.mint(msg, fee, memo, _funds), options);
 }
 export interface Sg721RevokeAllMutation {
   client: Sg721Client;
@@ -1180,7 +1180,7 @@ export interface Sg721RevokeAllMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeAllMutation>, \\"mutationFn\\">) {
@@ -1190,9 +1190,9 @@ export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<Exec
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.revokeAll(msg, fee, memo, funds), options);
+  }) => client.revokeAll(msg, fee, memo, _funds), options);
 }
 export interface Sg721ApproveAllMutation {
   client: Sg721Client;
@@ -1203,7 +1203,7 @@ export interface Sg721ApproveAllMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveAllMutation>, \\"mutationFn\\">) {
@@ -1213,9 +1213,9 @@ export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<Exe
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.approveAll(msg, fee, memo, funds), options);
+  }) => client.approveAll(msg, fee, memo, _funds), options);
 }
 export interface Sg721RevokeMutation {
   client: Sg721Client;
@@ -1226,7 +1226,7 @@ export interface Sg721RevokeMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeMutation>, \\"mutationFn\\">) {
@@ -1236,9 +1236,9 @@ export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<Execute
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.revoke(msg, fee, memo, funds), options);
+  }) => client.revoke(msg, fee, memo, _funds), options);
 }
 export interface Sg721ApproveMutation {
   client: Sg721Client;
@@ -1250,7 +1250,7 @@ export interface Sg721ApproveMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveMutation>, \\"mutationFn\\">) {
@@ -1260,9 +1260,9 @@ export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<Execut
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.approve(msg, fee, memo, funds), options);
+  }) => client.approve(msg, fee, memo, _funds), options);
 }
 export interface Sg721SendNftMutation {
   client: Sg721Client;
@@ -1274,7 +1274,7 @@ export interface Sg721SendNftMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721SendNftMutation>, \\"mutationFn\\">) {
@@ -1284,9 +1284,9 @@ export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<Execut
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.sendNft(msg, fee, memo, funds), options);
+  }) => client.sendNft(msg, fee, memo, _funds), options);
 }
 export interface Sg721TransferNftMutation {
   client: Sg721Client;
@@ -1297,7 +1297,7 @@ export interface Sg721TransferNftMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721TransferNftMutation>, \\"mutationFn\\">) {
@@ -1307,9 +1307,9 @@ export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<Ex
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.transferNft(msg, fee, memo, funds), options);
+  }) => client.transferNft(msg, fee, memo, _funds), options);
 }"
 `;
 
@@ -1320,7 +1320,7 @@ exports[`ownership 1`] = `
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useOwnershipUpdateOwnershipMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, OwnershipUpdateOwnershipMutation>, \\"mutationFn\\">) {
@@ -1330,9 +1330,9 @@ export function useOwnershipUpdateOwnershipMutation(options?: Omit<UseMutationOp
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.updateOwnership(msg, fee, memo, funds), options);
+  }) => client.updateOwnership(msg, fee, memo, _funds), options);
 }
 export interface OwnershipSetFactoryMutation {
   client: OwnershipClient;
@@ -1342,7 +1342,7 @@ export interface OwnershipSetFactoryMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    funds?: Coin[];
+    _funds?: Coin[];
   };
 }
 export function useOwnershipSetFactoryMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, OwnershipSetFactoryMutation>, \\"mutationFn\\">) {
@@ -1352,8 +1352,8 @@ export function useOwnershipSetFactoryMutation(options?: Omit<UseMutationOptions
     args: {
       fee,
       memo,
-      funds
+      _funds
     } = {}
-  }) => client.setFactory(msg, fee, memo, funds), options);
+  }) => client.setFactory(msg, fee, memo, _funds), options);
 }"
 `;

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -1133,7 +1133,7 @@ exports[`createReactQueryHooks 6`] = `
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721BurnMutation>, \\"mutationFn\\">) {
@@ -1158,7 +1158,7 @@ export interface Sg721MintMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721MintMutation>, \\"mutationFn\\">) {
@@ -1180,7 +1180,7 @@ export interface Sg721RevokeAllMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeAllMutation>, \\"mutationFn\\">) {
@@ -1203,7 +1203,7 @@ export interface Sg721ApproveAllMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveAllMutation>, \\"mutationFn\\">) {
@@ -1226,7 +1226,7 @@ export interface Sg721RevokeMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721RevokeMutation>, \\"mutationFn\\">) {
@@ -1250,7 +1250,7 @@ export interface Sg721ApproveMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721ApproveMutation>, \\"mutationFn\\">) {
@@ -1274,7 +1274,7 @@ export interface Sg721SendNftMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721SendNftMutation>, \\"mutationFn\\">) {
@@ -1297,7 +1297,7 @@ export interface Sg721TransferNftMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, Sg721TransferNftMutation>, \\"mutationFn\\">) {
@@ -1320,7 +1320,7 @@ exports[`ownership 1`] = `
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useOwnershipUpdateOwnershipMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, OwnershipUpdateOwnershipMutation>, \\"mutationFn\\">) {
@@ -1342,7 +1342,7 @@ export interface OwnershipSetFactoryMutation {
   args?: {
     fee?: number | StdFee | \\"auto\\";
     memo?: string;
-    _funds?: Coin[];
+    funds?: Coin[];
   };
 }
 export function useOwnershipSetFactoryMutation(options?: Omit<UseMutationOptions<ExecuteResult, Error, OwnershipSetFactoryMutation>, \\"mutationFn\\">) {

--- a/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
+++ b/packages/wasm-ast-types/src/react-query/__snapshots__/react-query.spec.ts.snap
@@ -1143,9 +1143,9 @@ export function useSg721BurnMutation(options?: Omit<UseMutationOptions<ExecuteRe
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.burn(msg, fee, memo, _funds), options);
+  }) => client.burn(msg, fee, memo, funds), options);
 }
 export interface Sg721MintMutation {
   client: Sg721Client;
@@ -1168,9 +1168,9 @@ export function useSg721MintMutation(options?: Omit<UseMutationOptions<ExecuteRe
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.mint(msg, fee, memo, _funds), options);
+  }) => client.mint(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeAllMutation {
   client: Sg721Client;
@@ -1190,9 +1190,9 @@ export function useSg721RevokeAllMutation(options?: Omit<UseMutationOptions<Exec
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.revokeAll(msg, fee, memo, _funds), options);
+  }) => client.revokeAll(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveAllMutation {
   client: Sg721Client;
@@ -1213,9 +1213,9 @@ export function useSg721ApproveAllMutation(options?: Omit<UseMutationOptions<Exe
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.approveAll(msg, fee, memo, _funds), options);
+  }) => client.approveAll(msg, fee, memo, funds), options);
 }
 export interface Sg721RevokeMutation {
   client: Sg721Client;
@@ -1236,9 +1236,9 @@ export function useSg721RevokeMutation(options?: Omit<UseMutationOptions<Execute
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.revoke(msg, fee, memo, _funds), options);
+  }) => client.revoke(msg, fee, memo, funds), options);
 }
 export interface Sg721ApproveMutation {
   client: Sg721Client;
@@ -1260,9 +1260,9 @@ export function useSg721ApproveMutation(options?: Omit<UseMutationOptions<Execut
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.approve(msg, fee, memo, _funds), options);
+  }) => client.approve(msg, fee, memo, funds), options);
 }
 export interface Sg721SendNftMutation {
   client: Sg721Client;
@@ -1284,9 +1284,9 @@ export function useSg721SendNftMutation(options?: Omit<UseMutationOptions<Execut
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.sendNft(msg, fee, memo, _funds), options);
+  }) => client.sendNft(msg, fee, memo, funds), options);
 }
 export interface Sg721TransferNftMutation {
   client: Sg721Client;
@@ -1307,9 +1307,9 @@ export function useSg721TransferNftMutation(options?: Omit<UseMutationOptions<Ex
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.transferNft(msg, fee, memo, _funds), options);
+  }) => client.transferNft(msg, fee, memo, funds), options);
 }"
 `;
 
@@ -1330,9 +1330,9 @@ export function useOwnershipUpdateOwnershipMutation(options?: Omit<UseMutationOp
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.updateOwnership(msg, fee, memo, _funds), options);
+  }) => client.updateOwnership(msg, fee, memo, funds), options);
 }
 export interface OwnershipSetFactoryMutation {
   client: OwnershipClient;
@@ -1352,8 +1352,8 @@ export function useOwnershipSetFactoryMutation(options?: Omit<UseMutationOptions
     args: {
       fee,
       memo,
-      _funds
+      funds
     } = {}
-  }) => client.setFactory(msg, fee, memo, _funds), options);
+  }) => client.setFactory(msg, fee, memo, funds), options);
 }"
 `;

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -431,14 +431,7 @@ export const createReactQueryMutationArgsInterface = ({
       t.tsTypeLiteral([
         propertySignature('fee', OPTIONAL_FEE_PARAM.typeAnnotation, true),
         propertySignature('memo', OPTIONAL_MEMO_PARAM.typeAnnotation, true),
-        {
-          ...propertySignature(
-            'funds',
-            OPTIONAL_FUNDS_PARAM.typeAnnotation,
-            true
-          ),
-          value: '_funds'
-        }
+        propertySignature('funds', OPTIONAL_FUNDS_PARAM.typeAnnotation, true)
       ])
     )
   );
@@ -573,9 +566,11 @@ export const createReactQueryMutationHook = ({
     t.objectProperty(
       t.identifier('args'),
       t.assignmentPattern(
-        t.objectPattern(
-          FIXED_EXECUTE_PARAMS.map((param) => shorthandProperty(param.name))
-        ),
+        t.objectPattern([
+          shorthandProperty('fee'),
+          shorthandProperty('memo'),
+          shorthandProperty('funds')
+        ]),
         t.objectExpression([])
       )
     )
@@ -611,11 +606,11 @@ export const createReactQueryMutationHook = ({
                     t.identifier('client'),
                     t.identifier(execMethodName)
                   ),
-                  (hasMsg ? [t.identifier('msg')] : []).concat(
-                    FIXED_EXECUTE_PARAMS.map((param) =>
-                      t.identifier(param.name)
-                    )
-                  )
+                  (hasMsg ? [t.identifier('msg')] : []).concat([
+                    t.identifier('fee'),
+                    t.identifier('memo'),
+                    t.identifier('funds')
+                  ])
                 ),
                 false // not async
               ),

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -4,7 +4,7 @@ import { camel, pascal } from 'case';
 import { ExecuteMsg, QueryMsg } from '../types';
 import {
   callExpression,
-  createTypedObjectParams,
+  createTypedObjectParams, FIXED_EXECUTE_PARAMS,
   getMessageProperties,
   identifier,
   tsObjectPattern,
@@ -24,7 +24,6 @@ import {
 } from '../utils/types';
 import { ReactQueryOptions, RenderContext } from '../context';
 import { JSONSchema } from '../types';
-import { FIXED_EXECUTE_PARAMS } from '../client';
 import { ArrowFunctionExpression, objectExpression } from '@babel/types';
 
 interface ReactQueryHookQuery {

--- a/packages/wasm-ast-types/src/utils/babel.ts
+++ b/packages/wasm-ast-types/src/utils/babel.ts
@@ -1,18 +1,19 @@
 import * as t from '@babel/types';
 import { snake } from "case";
 import { Field, QueryMsg, ExecuteMsg } from '../types';
-import { TSTypeAnnotation, TSExpressionWithTypeArguments } from '@babel/types';
+import { TSTypeAnnotation, TSExpressionWithTypeArguments, Noop, TypeAnnotation } from '@babel/types';
 import { refLookup } from './ref';
 
 // t.TSPropertySignature - kind?
 export const propertySignature = (
     name: string,
-    typeAnnotation: t.TSTypeAnnotation,
+    typeAnnotation: TSTypeAnnotation,
     optional: boolean = false
-) => {
+): t.TSPropertySignature => {
     return {
         type: 'TSPropertySignature',
         key: t.identifier(name),
+      kind: 'get',
         typeAnnotation,
         optional
     }

--- a/packages/wasm-ast-types/src/utils/constants.ts
+++ b/packages/wasm-ast-types/src/utils/constants.ts
@@ -6,18 +6,25 @@ export const OPTIONAL_FUNDS_PARAM = identifier(
   t.tsTypeAnnotation(t.tsArrayType(t.tsTypeReference(t.identifier('Coin')))),
   true
 );
-export const FIXED_EXECUTE_PARAMS = [
-  identifier(
-    'fee',
-    t.tsTypeAnnotation(
-      t.tsUnionType([
-        t.tsNumberKeyword(),
-        t.tsTypeReference(t.identifier('StdFee')),
-        t.tsLiteralType(t.stringLiteral('auto'))
-      ])
-    ),
-    true
+export const OPTIONAL_FEE_PARAM = identifier(
+  'fee',
+  t.tsTypeAnnotation(
+    t.tsUnionType([
+      t.tsNumberKeyword(),
+      t.tsTypeReference(t.identifier('StdFee')),
+      t.tsLiteralType(t.stringLiteral('auto'))
+    ])
   ),
-  identifier('memo', t.tsTypeAnnotation(t.tsStringKeyword()), true),
+  true
+);
+export const OPTIONAL_MEMO_PARAM = identifier(
+  'memo',
+  t.tsTypeAnnotation(t.tsStringKeyword()),
+  true
+);
+
+export const FIXED_EXECUTE_PARAMS = [
+  OPTIONAL_FEE_PARAM,
+  OPTIONAL_MEMO_PARAM,
   OPTIONAL_FUNDS_PARAM
 ];

--- a/packages/wasm-ast-types/src/utils/constants.ts
+++ b/packages/wasm-ast-types/src/utils/constants.ts
@@ -1,0 +1,23 @@
+import { identifier } from './babel';
+import * as t from '@babel/types';
+
+export const OPTIONAL_FUNDS_PARAM = identifier(
+  '_funds',
+  t.tsTypeAnnotation(t.tsArrayType(t.tsTypeReference(t.identifier('Coin')))),
+  true
+);
+export const FIXED_EXECUTE_PARAMS = [
+  identifier(
+    'fee',
+    t.tsTypeAnnotation(
+      t.tsUnionType([
+        t.tsNumberKeyword(),
+        t.tsTypeReference(t.identifier('StdFee')),
+        t.tsLiteralType(t.stringLiteral('auto'))
+      ])
+    ),
+    true
+  ),
+  identifier('memo', t.tsTypeAnnotation(t.tsStringKeyword()), true),
+  OPTIONAL_FUNDS_PARAM
+];

--- a/packages/wasm-ast-types/src/utils/index.ts
+++ b/packages/wasm-ast-types/src/utils/index.ts
@@ -1,3 +1,5 @@
 export * from './babel';
 export * from './types';
 export * from './ref';
+export { OPTIONAL_FUNDS_PARAM } from './constants';
+export { FIXED_EXECUTE_PARAMS } from './constants';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9218,16 +9218,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-"wasm-ast-types@file:packages/wasm-ast-types":
-  version "0.21.0"
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@babel/types" "7.18.10"
-    "@jest/transform" "28.1.3"
-    ast-stringify "0.1.0"
-    case "1.6.3"
-    deepmerge "4.2.2"
-
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9218,6 +9218,16 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
+"wasm-ast-types@file:packages/wasm-ast-types":
+  version "0.21.0"
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@babel/types" "7.18.10"
+    "@jest/transform" "28.1.3"
+    ast-stringify "0.1.0"
+    case "1.6.3"
+    deepmerge "4.2.2"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9218,18 +9218,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-"wasm-ast-types@path:../wasm-ast-types":
-  version "0.17.0"
-  resolved "https://registry.npmjs.org/wasm-ast-types/-/wasm-ast-types-0.17.0.tgz#417280a61d60ea9964667cf2edb8f5281dc295d7"
-  integrity sha512-WeriXPbG67iI51Mf/5qRR0xcpEaTO/Wyjpl+vsmjZ5K6q/0W6iO03zHsESNIH/hpc5FPTpb0Y0L9xAtnnNe9Ow==
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@babel/types" "7.18.10"
-    "@jest/transform" "28.1.3"
-    ast-stringify "0.1.0"
-    case "1.6.3"
-    deepmerge "4.2.2"
-
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"


### PR DESCRIPTION
This change ensures that the `funds` parameter for message composer and the client generation are underscored to avoid conflicts with variables in the messages themselves.

We should do the same for `fee` and `memo` in the future
