### PR TITLE
Add aliasEntryPoints option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ Typescript types and interfaces are generated in separate files so they can be i
 
 #### Types Options
 
-  | option                        | description                                          |
-  | ----------------------------- | ---------------------------------------------------  |
-  | `types.enabled`               | enable type generation                               |
-  | `types.aliasExecuteMsg`       | generate a type alias based on the contract name     |
+  | option                  | description                                          |
+-------------------------| ----------------------------- | ---------------------------------------------------  |
+  | `types.enabled`         | enable type generation                               |
+  | `types.aliasExecuteMsg` | generate a type alias based on the contract name     |
+  | `types.aliasEntryPoints`               | generate type aliases for the entry points based on the contract name     |
 
 ### Client
 

--- a/packages/ts-codegen/README.md
+++ b/packages/ts-codegen/README.md
@@ -141,6 +141,7 @@ Typescript types and interfaces are generated in separate files so they can be i
   | ----------------------------- | ---------------------------------------------------  |
   | `types.enabled`               | enable type generation                               |
   | `types.aliasExecuteMsg`       | generate a type alias based on the contract name     |
+  | `types.aliasEntryPoints`               | generate type aliases for the entry points based on the contract name     |
 
 ### Client
 

--- a/packages/wasm-ast-types/src/context/context.ts
+++ b/packages/wasm-ast-types/src/context/context.ts
@@ -30,7 +30,9 @@ export interface RecoilOptions {
 }
 export interface TSTypesOptions {
     enabled?: boolean;
+    // deprecated
     aliasExecuteMsg?: boolean;
+    aliasEntryPoints?: boolean;
 }
 
 /// END Plugin Types

--- a/packages/wasm-ast-types/types/context/context.d.ts
+++ b/packages/wasm-ast-types/types/context/context.d.ts
@@ -25,7 +25,9 @@ export interface RecoilOptions {
 }
 export interface TSTypesOptions {
     enabled?: boolean;
+    // deprecated
     aliasExecuteMsg?: boolean;
+    aliasEntryPoints?: boolean;
 }
 interface KeyedSchema {
     [key: string]: JSONSchema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9218,18 +9218,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-"wasm-ast-types@path:../wasm-ast-types":
-  version "0.17.0"
-  resolved "https://registry.npmjs.org/wasm-ast-types/-/wasm-ast-types-0.17.0.tgz#417280a61d60ea9964667cf2edb8f5281dc295d7"
-  integrity sha512-WeriXPbG67iI51Mf/5qRR0xcpEaTO/Wyjpl+vsmjZ5K6q/0W6iO03zHsESNIH/hpc5FPTpb0Y0L9xAtnnNe9Ow==
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@babel/types" "7.18.10"
-    "@jest/transform" "28.1.3"
-    ast-stringify "0.1.0"
-    case "1.6.3"
-    deepmerge "4.2.2"
-
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"


### PR DESCRIPTION
This change adds the option to alias the entry points. In the future, it should be extended for the MigrateMsg and InstantiateMsg as well.