### PR TITLE
Suffix fee, memo, and funds with underscores

### DIFF
--- a/__fixtures__/issues/98/out/98.client.ts
+++ b/__fixtures__/issues/98/out/98.client.ts
@@ -144,7 +144,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
   }: {
     id: number;
     instantiateMsg: Binary;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proxy_install_plugin: {
         id,
@@ -166,7 +166,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash: string;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register_plugin: {
         checksum,
@@ -182,7 +182,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     id
   }: {
     id: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister_plugin: {
         id
@@ -205,7 +205,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash?: string;
     name?: string;
     version?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_plugin: {
         checksum,
@@ -222,7 +222,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_registry_fee: {
         new_fee: newFee
@@ -233,7 +233,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     newAddr
   }: {
     newAddr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_dao_addr: {
         new_addr: newAddr

--- a/__fixtures__/issues/98/out/98.client.ts
+++ b/__fixtures__/issues/98/out/98.client.ts
@@ -73,7 +73,7 @@ export interface 98Interface extends 98ReadOnlyInterface {
   }: {
     id: number;
     instantiateMsg: Binary;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   registerPlugin: ({
     checksum,
     codeId,
@@ -88,12 +88,12 @@ export interface 98Interface extends 98ReadOnlyInterface {
     ipfsHash: string;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregisterPlugin: ({
     id
   }: {
     id: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePlugin: ({
     checksum,
     codeId,
@@ -110,17 +110,17 @@ export interface 98Interface extends 98ReadOnlyInterface {
     ipfsHash?: string;
     name?: string;
     version?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateRegistryFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateDaoAddr: ({
     newAddr
   }: {
     newAddr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class 98Client extends 98QueryClient implements 98Interface {
   client: SigningCosmWasmClient;
@@ -144,13 +144,13 @@ export class 98Client extends 98QueryClient implements 98Interface {
   }: {
     id: number;
     instantiateMsg: Binary;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proxy_install_plugin: {
         id,
         instantiate_msg: instantiateMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   registerPlugin = async ({
     checksum,
@@ -166,7 +166,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash: string;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register_plugin: {
         checksum,
@@ -176,18 +176,18 @@ export class 98Client extends 98QueryClient implements 98Interface {
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregisterPlugin = async ({
     id
   }: {
     id: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister_plugin: {
         id
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePlugin = async ({
     checksum,
@@ -205,7 +205,7 @@ export class 98Client extends 98QueryClient implements 98Interface {
     ipfsHash?: string;
     name?: string;
     version?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_plugin: {
         checksum,
@@ -216,28 +216,28 @@ export class 98Client extends 98QueryClient implements 98Interface {
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateRegistryFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_registry_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateDaoAddr = async ({
     newAddr
   }: {
     newAddr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_dao_addr: {
         new_addr: newAddr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
@@ -29,7 +29,7 @@ export interface CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -49,13 +49,13 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.client.ts
@@ -49,7 +49,7 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,

--- a/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
   sender: string;
@@ -38,7 +38,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -51,7 +51,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
             label
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
@@ -167,7 +167,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -188,7 +188,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -207,7 +207,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
@@ -222,7 +222,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
@@ -236,7 +236,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.client.ts
@@ -107,7 +107,7 @@ export interface CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -120,7 +120,7 @@ export interface CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -129,21 +129,21 @@ export interface CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -167,14 +167,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   register = async ({
     chainId,
@@ -188,7 +188,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -197,7 +197,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setOwner = async ({
     chainId,
@@ -207,14 +207,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregister = async ({
     chainId,
@@ -222,13 +222,13 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     admin,
@@ -236,12 +236,12 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   sender: string;
@@ -78,7 +78,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -91,7 +91,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             sender
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -107,7 +107,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -122,7 +122,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             version
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -134,7 +134,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,7 +147,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             owner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -157,7 +157,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             code_id: codeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             payment_info: paymentInfo
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/CwSingle.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.client.ts
@@ -174,24 +174,24 @@ export interface CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -208,27 +208,27 @@ export interface CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -256,14 +256,14 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -271,35 +271,35 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -317,7 +317,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -328,50 +328,50 @@ export class CwSingleClient implements CwSingleInterface {
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/CwSingle.client.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.client.ts
@@ -256,7 +256,7 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -271,7 +271,7 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -283,7 +283,7 @@ export class CwSingleClient implements CwSingleInterface {
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -294,7 +294,7 @@ export class CwSingleClient implements CwSingleInterface {
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -317,7 +317,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -334,7 +334,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -345,7 +345,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -356,7 +356,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -367,7 +367,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMsgComposer implements CwSingleMsg {
   sender: string;
@@ -99,7 +99,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             title
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -122,7 +122,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -134,7 +134,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             vote
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -142,7 +142,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -153,7 +153,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -161,7 +161,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -172,7 +172,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -192,7 +192,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -209,7 +209,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             threshold
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -217,7 +217,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -228,7 +228,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -236,7 +236,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -247,7 +247,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -255,7 +255,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -266,7 +266,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -274,7 +274,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -285,7 +285,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Factory.client.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.client.ts
@@ -170,7 +170,7 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
@@ -183,7 +183,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
@@ -197,7 +197,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
@@ -211,7 +211,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
@@ -223,7 +223,7 @@ export class FactoryClient implements FactoryInterface {
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
@@ -234,7 +234,7 @@ export class FactoryClient implements FactoryInterface {
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
@@ -245,7 +245,7 @@ export class FactoryClient implements FactoryInterface {
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr

--- a/__output__/builder/bundler_test/contracts/Factory.client.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.client.ts
@@ -112,43 +112,43 @@ export interface FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -170,12 +170,12 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateProxyUser = async ({
     newUser,
@@ -183,13 +183,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -197,13 +197,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCodeId = async ({
     newCodeId,
@@ -211,45 +211,45 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMsgComposer implements FactoryMsg {
   sender: string;
@@ -71,7 +71,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,7 +82,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -92,7 +92,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -104,7 +104,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             old_user: oldUser
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -114,7 +114,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -126,7 +126,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             wallet_address: walletAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -136,7 +136,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -148,7 +148,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             ty
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -156,7 +156,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             new_fee: newFee
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -175,7 +175,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -186,7 +186,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -194,7 +194,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -205,7 +205,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/bundler_test/contracts/Minter.client.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.client.ts
@@ -108,7 +108,7 @@ export class MinterClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
     }, fee_, memo_, funds_);
@@ -117,14 +117,14 @@ export class MinterClient implements MinterInterface {
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
     }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
     }, fee_, memo_, funds_);
@@ -133,7 +133,7 @@ export class MinterClient implements MinterInterface {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
@@ -144,7 +144,7 @@ export class MinterClient implements MinterInterface {
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
@@ -157,7 +157,7 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
@@ -165,7 +165,7 @@ export class MinterClient implements MinterInterface {
       }
     }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
     }, fee_, memo_, funds_);

--- a/__output__/builder/bundler_test/contracts/Minter.client.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.client.ts
@@ -66,31 +66,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -108,48 +108,48 @@ export class MinterClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintFor = async ({
     recipient,
@@ -157,17 +157,17 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
+++ b/__output__/builder/bundler_test/contracts/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMsg {
   contractAddress: string;
   sender: string;
-  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMsgComposer implements MinterMsg {
   sender: string;
@@ -51,7 +51,7 @@ export class MinterMsgComposer implements MinterMsg {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -60,7 +60,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -68,7 +68,7 @@ export class MinterMsgComposer implements MinterMsg {
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -79,11 +79,11 @@ export class MinterMsgComposer implements MinterMsg {
             whitelist
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -92,7 +92,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -100,7 +100,7 @@ export class MinterMsgComposer implements MinterMsg {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -111,7 +111,7 @@ export class MinterMsgComposer implements MinterMsg {
             per_address_limit: perAddressLimit
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -119,7 +119,7 @@ export class MinterMsgComposer implements MinterMsg {
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -130,7 +130,7 @@ export class MinterMsgComposer implements MinterMsg {
             recipient
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -140,7 +140,7 @@ export class MinterMsgComposer implements MinterMsg {
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,11 +152,11 @@ export class MinterMsgComposer implements MinterMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -165,7 +165,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/default/CwAdminFactory.client.ts
+++ b/__output__/builder/default/CwAdminFactory.client.ts
@@ -29,7 +29,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -50,13 +50,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/default/CwAdminFactory.client.ts
+++ b/__output__/builder/default/CwAdminFactory.client.ts
@@ -50,7 +50,7 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,

--- a/__output__/builder/default/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/default/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
   sender: string;
@@ -38,7 +38,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -51,7 +51,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
             label
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/default/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.client.ts
@@ -168,7 +168,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -208,7 +208,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
@@ -223,7 +223,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
@@ -237,7 +237,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,

--- a/__output__/builder/default/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.client.ts
@@ -107,7 +107,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -120,7 +120,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -129,21 +129,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -168,14 +168,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   register = async ({
     chainId,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -198,7 +198,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setOwner = async ({
     chainId,
@@ -208,14 +208,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregister = async ({
     chainId,
@@ -223,13 +223,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     admin,
@@ -237,12 +237,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/default/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   sender: string;
@@ -78,7 +78,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -91,7 +91,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             sender
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -107,7 +107,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -122,7 +122,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             version
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -134,7 +134,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,7 +147,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             owner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -157,7 +157,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             code_id: codeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             payment_info: paymentInfo
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/default/CwSingle.client.ts
+++ b/__output__/builder/default/CwSingle.client.ts
@@ -174,24 +174,24 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -208,27 +208,27 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient extends CwSingleQueryClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -257,14 +257,14 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -272,35 +272,35 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -318,7 +318,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -329,50 +329,50 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/default/CwSingle.client.ts
+++ b/__output__/builder/default/CwSingle.client.ts
@@ -257,7 +257,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -272,7 +272,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -284,7 +284,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -295,7 +295,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -318,7 +318,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -335,7 +335,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -346,7 +346,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -357,7 +357,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -368,7 +368,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/__output__/builder/default/CwSingle.message-composer.ts
+++ b/__output__/builder/default/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMsgComposer implements CwSingleMsg {
   sender: string;
@@ -99,7 +99,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             title
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -122,7 +122,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -134,7 +134,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             vote
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -142,7 +142,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -153,7 +153,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -161,7 +161,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -172,7 +172,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -192,7 +192,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -209,7 +209,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             threshold
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -217,7 +217,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -228,7 +228,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -236,7 +236,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -247,7 +247,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -255,7 +255,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -266,7 +266,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -274,7 +274,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -285,7 +285,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/default/Factory.client.ts
+++ b/__output__/builder/default/Factory.client.ts
@@ -171,7 +171,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
@@ -184,7 +184,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
@@ -198,7 +198,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
@@ -212,7 +212,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
@@ -224,7 +224,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
@@ -235,7 +235,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
@@ -246,7 +246,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr

--- a/__output__/builder/default/Factory.client.ts
+++ b/__output__/builder/default/Factory.client.ts
@@ -112,43 +112,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -171,12 +171,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateProxyUser = async ({
     newUser,
@@ -184,13 +184,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -198,13 +198,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCodeId = async ({
     newCodeId,
@@ -212,45 +212,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/default/Factory.message-composer.ts
+++ b/__output__/builder/default/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMsgComposer implements FactoryMsg {
   sender: string;
@@ -71,7 +71,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,7 +82,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -92,7 +92,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -104,7 +104,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             old_user: oldUser
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -114,7 +114,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -126,7 +126,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             wallet_address: walletAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -136,7 +136,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -148,7 +148,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             ty
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -156,7 +156,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             new_fee: newFee
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -175,7 +175,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -186,7 +186,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -194,7 +194,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -205,7 +205,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/default/Minter.client.ts
+++ b/__output__/builder/default/Minter.client.ts
@@ -66,31 +66,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -109,48 +109,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintFor = async ({
     recipient,
@@ -158,17 +158,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/default/Minter.client.ts
+++ b/__output__/builder/default/Minter.client.ts
@@ -109,7 +109,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
     }, fee_, memo_, funds_);
@@ -118,14 +118,14 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
     }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
     }, fee_, memo_, funds_);
@@ -134,7 +134,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
@@ -145,7 +145,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
@@ -158,7 +158,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
@@ -166,7 +166,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
       }
     }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
     }, fee_, memo_, funds_);

--- a/__output__/builder/default/Minter.message-composer.ts
+++ b/__output__/builder/default/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMsg {
   contractAddress: string;
   sender: string;
-  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMsgComposer implements MinterMsg {
   sender: string;
@@ -51,7 +51,7 @@ export class MinterMsgComposer implements MinterMsg {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -60,7 +60,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -68,7 +68,7 @@ export class MinterMsgComposer implements MinterMsg {
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -79,11 +79,11 @@ export class MinterMsgComposer implements MinterMsg {
             whitelist
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -92,7 +92,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -100,7 +100,7 @@ export class MinterMsgComposer implements MinterMsg {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -111,7 +111,7 @@ export class MinterMsgComposer implements MinterMsg {
             per_address_limit: perAddressLimit
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -119,7 +119,7 @@ export class MinterMsgComposer implements MinterMsg {
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -130,7 +130,7 @@ export class MinterMsgComposer implements MinterMsg {
             recipient
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -140,7 +140,7 @@ export class MinterMsgComposer implements MinterMsg {
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,11 +152,11 @@ export class MinterMsgComposer implements MinterMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -165,7 +165,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/invoke/CwAdminFactory.client.ts
+++ b/__output__/builder/invoke/CwAdminFactory.client.ts
@@ -29,7 +29,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -50,13 +50,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/invoke/CwAdminFactory.client.ts
+++ b/__output__/builder/invoke/CwAdminFactory.client.ts
@@ -50,7 +50,7 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,

--- a/__output__/builder/invoke/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/invoke/CwCodeIdRegistry.client.ts
@@ -168,7 +168,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -208,7 +208,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
@@ -223,7 +223,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
@@ -237,7 +237,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,

--- a/__output__/builder/invoke/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/invoke/CwCodeIdRegistry.client.ts
@@ -107,7 +107,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -120,7 +120,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -129,21 +129,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -168,14 +168,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   register = async ({
     chainId,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -198,7 +198,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setOwner = async ({
     chainId,
@@ -208,14 +208,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregister = async ({
     chainId,
@@ -223,13 +223,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     admin,
@@ -237,12 +237,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/invoke/CwSingle.client.ts
+++ b/__output__/builder/invoke/CwSingle.client.ts
@@ -174,24 +174,24 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -208,27 +208,27 @@ export interface CwSingleInterface extends CwSingleReadOnlyInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient extends CwSingleQueryClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -257,14 +257,14 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -272,35 +272,35 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -318,7 +318,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -329,50 +329,50 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/invoke/CwSingle.client.ts
+++ b/__output__/builder/invoke/CwSingle.client.ts
@@ -257,7 +257,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -272,7 +272,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -284,7 +284,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -295,7 +295,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -318,7 +318,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -335,7 +335,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -346,7 +346,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -357,7 +357,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -368,7 +368,7 @@ export class CwSingleClient extends CwSingleQueryClient implements CwSingleInter
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/__output__/builder/invoke/Factory.client.ts
+++ b/__output__/builder/invoke/Factory.client.ts
@@ -171,7 +171,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
@@ -184,7 +184,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
@@ -198,7 +198,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
@@ -212,7 +212,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
@@ -224,7 +224,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
@@ -235,7 +235,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
@@ -246,7 +246,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr

--- a/__output__/builder/invoke/Factory.client.ts
+++ b/__output__/builder/invoke/Factory.client.ts
@@ -112,43 +112,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -171,12 +171,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateProxyUser = async ({
     newUser,
@@ -184,13 +184,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -198,13 +198,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCodeId = async ({
     newCodeId,
@@ -212,45 +212,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/invoke/Minter.client.ts
+++ b/__output__/builder/invoke/Minter.client.ts
@@ -66,31 +66,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -109,48 +109,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintFor = async ({
     recipient,
@@ -158,17 +158,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/invoke/Minter.client.ts
+++ b/__output__/builder/invoke/Minter.client.ts
@@ -109,7 +109,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
     }, fee_, memo_, funds_);
@@ -118,14 +118,14 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
     }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
     }, fee_, memo_, funds_);
@@ -134,7 +134,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
@@ -145,7 +145,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
@@ -158,7 +158,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
@@ -166,7 +166,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
       }
     }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
     }, fee_, memo_, funds_);

--- a/__output__/builder/no-extends/CwAdminFactory.client.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.client.ts
@@ -29,7 +29,7 @@ export interface CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -49,13 +49,13 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/no-extends/CwAdminFactory.client.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.client.ts
@@ -49,7 +49,7 @@ export class CwAdminFactoryClient implements CwAdminFactoryInterface {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,

--- a/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
+++ b/__output__/builder/no-extends/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
   sender: string;
@@ -38,7 +38,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -51,7 +51,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
             label
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
@@ -167,7 +167,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -188,7 +188,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -207,7 +207,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
@@ -222,7 +222,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
@@ -236,7 +236,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,

--- a/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.client.ts
@@ -107,7 +107,7 @@ export interface CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -120,7 +120,7 @@ export interface CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -129,21 +129,21 @@ export interface CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -167,14 +167,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   register = async ({
     chainId,
@@ -188,7 +188,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -197,7 +197,7 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setOwner = async ({
     chainId,
@@ -207,14 +207,14 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregister = async ({
     chainId,
@@ -222,13 +222,13 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     admin,
@@ -236,12 +236,12 @@ export class CwCodeIdRegistryClient implements CwCodeIdRegistryInterface {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/builder/no-extends/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   sender: string;
@@ -78,7 +78,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -91,7 +91,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             sender
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -107,7 +107,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -122,7 +122,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             version
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -134,7 +134,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,7 +147,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             owner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -157,7 +157,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             code_id: codeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             payment_info: paymentInfo
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/no-extends/CwSingle.client.ts
+++ b/__output__/builder/no-extends/CwSingle.client.ts
@@ -174,24 +174,24 @@ export interface CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -208,27 +208,27 @@ export interface CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwSingleClient implements CwSingleInterface {
   client: SigningCosmWasmClient;
@@ -256,14 +256,14 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -271,35 +271,35 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -317,7 +317,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -328,50 +328,50 @@ export class CwSingleClient implements CwSingleInterface {
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/no-extends/CwSingle.client.ts
+++ b/__output__/builder/no-extends/CwSingle.client.ts
@@ -256,7 +256,7 @@ export class CwSingleClient implements CwSingleInterface {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -271,7 +271,7 @@ export class CwSingleClient implements CwSingleInterface {
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -283,7 +283,7 @@ export class CwSingleClient implements CwSingleInterface {
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -294,7 +294,7 @@ export class CwSingleClient implements CwSingleInterface {
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -317,7 +317,7 @@ export class CwSingleClient implements CwSingleInterface {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -334,7 +334,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -345,7 +345,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -356,7 +356,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -367,7 +367,7 @@ export class CwSingleClient implements CwSingleInterface {
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/__output__/builder/no-extends/CwSingle.message-composer.ts
+++ b/__output__/builder/no-extends/CwSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwSingleMsgComposer implements CwSingleMsg {
   sender: string;
@@ -99,7 +99,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             title
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -122,7 +122,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -134,7 +134,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             vote
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -142,7 +142,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -153,7 +153,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -161,7 +161,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -172,7 +172,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -192,7 +192,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -209,7 +209,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             threshold
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -217,7 +217,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -228,7 +228,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -236,7 +236,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -247,7 +247,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -255,7 +255,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -266,7 +266,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -274,7 +274,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -285,7 +285,7 @@ export class CwSingleMsgComposer implements CwSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/no-extends/Factory.client.ts
+++ b/__output__/builder/no-extends/Factory.client.ts
@@ -170,7 +170,7 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
@@ -183,7 +183,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
@@ -197,7 +197,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
@@ -211,7 +211,7 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
@@ -223,7 +223,7 @@ export class FactoryClient implements FactoryInterface {
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
@@ -234,7 +234,7 @@ export class FactoryClient implements FactoryInterface {
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
@@ -245,7 +245,7 @@ export class FactoryClient implements FactoryInterface {
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr

--- a/__output__/builder/no-extends/Factory.client.ts
+++ b/__output__/builder/no-extends/Factory.client.ts
@@ -112,43 +112,43 @@ export interface FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -170,12 +170,12 @@ export class FactoryClient implements FactoryInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateProxyUser = async ({
     newUser,
@@ -183,13 +183,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -197,13 +197,13 @@ export class FactoryClient implements FactoryInterface {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCodeId = async ({
     newCodeId,
@@ -211,45 +211,45 @@ export class FactoryClient implements FactoryInterface {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/no-extends/Factory.message-composer.ts
+++ b/__output__/builder/no-extends/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMsgComposer implements FactoryMsg {
   sender: string;
@@ -71,7 +71,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,7 +82,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -92,7 +92,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -104,7 +104,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             old_user: oldUser
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -114,7 +114,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -126,7 +126,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             wallet_address: walletAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -136,7 +136,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -148,7 +148,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             ty
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -156,7 +156,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             new_fee: newFee
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -175,7 +175,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -186,7 +186,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -194,7 +194,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -205,7 +205,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/builder/no-extends/Minter.client.ts
+++ b/__output__/builder/no-extends/Minter.client.ts
@@ -108,7 +108,7 @@ export class MinterClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
     }, fee_, memo_, funds_);
@@ -117,14 +117,14 @@ export class MinterClient implements MinterInterface {
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
     }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
     }, fee_, memo_, funds_);
@@ -133,7 +133,7 @@ export class MinterClient implements MinterInterface {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
@@ -144,7 +144,7 @@ export class MinterClient implements MinterInterface {
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
@@ -157,7 +157,7 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
@@ -165,7 +165,7 @@ export class MinterClient implements MinterInterface {
       }
     }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
     }, fee_, memo_, funds_);

--- a/__output__/builder/no-extends/Minter.client.ts
+++ b/__output__/builder/no-extends/Minter.client.ts
@@ -66,31 +66,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -108,48 +108,48 @@ export class MinterClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintFor = async ({
     recipient,
@@ -157,17 +157,17 @@ export class MinterClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/builder/no-extends/Minter.message-composer.ts
+++ b/__output__/builder/no-extends/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMsg {
   contractAddress: string;
   sender: string;
-  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMsgComposer implements MinterMsg {
   sender: string;
@@ -51,7 +51,7 @@ export class MinterMsgComposer implements MinterMsg {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -60,7 +60,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -68,7 +68,7 @@ export class MinterMsgComposer implements MinterMsg {
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -79,11 +79,11 @@ export class MinterMsgComposer implements MinterMsg {
             whitelist
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -92,7 +92,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -100,7 +100,7 @@ export class MinterMsgComposer implements MinterMsg {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -111,7 +111,7 @@ export class MinterMsgComposer implements MinterMsg {
             per_address_limit: perAddressLimit
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -119,7 +119,7 @@ export class MinterMsgComposer implements MinterMsg {
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -130,7 +130,7 @@ export class MinterMsgComposer implements MinterMsg {
             recipient
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -140,7 +140,7 @@ export class MinterMsgComposer implements MinterMsg {
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,11 +152,11 @@ export class MinterMsgComposer implements MinterMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -165,7 +165,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
@@ -29,7 +29,7 @@ export interface CwAdminFactoryInterface extends CwAdminFactoryReadOnlyInterface
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements CwAdminFactoryInterface {
   client: SigningCosmWasmClient;
@@ -50,13 +50,13 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,
         instantiate_msg: instantiateMsg,
         label
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.client.ts
@@ -50,7 +50,7 @@ export class CwAdminFactoryClient extends CwAdminFactoryQueryClient implements C
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       instantiate_contract_with_self_admin: {
         code_id: codeId,

--- a/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
+++ b/__output__/daodao/cw-admin-factory/CwAdminFactory.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
   sender: string;
@@ -38,7 +38,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
     codeId: number;
     instantiateMsg: Binary;
     label: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -51,7 +51,7 @@ export class CwAdminFactoryMsgComposer implements CwAdminFactoryMsg {
             label
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
@@ -168,7 +168,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -208,7 +208,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
@@ -223,7 +223,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
@@ -237,7 +237,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.client.ts
@@ -107,7 +107,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   register: ({
     chainId,
     checksum,
@@ -120,7 +120,7 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     codeId: number;
     name: string;
     version: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setOwner: ({
     chainId,
     name,
@@ -129,21 +129,21 @@ export interface CwCodeIdRegistryInterface extends CwCodeIdRegistryReadOnlyInter
     chainId: string;
     name: string;
     owner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implements CwCodeIdRegistryInterface {
   client: SigningCosmWasmClient;
@@ -168,14 +168,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   register = async ({
     chainId,
@@ -189,7 +189,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     codeId: number;
     name: string;
     version: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       register: {
         chain_id: chainId,
@@ -198,7 +198,7 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
         name,
         version
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setOwner = async ({
     chainId,
@@ -208,14 +208,14 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
     chainId: string;
     name: string;
     owner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_owner: {
         chain_id: chainId,
         name,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   unregister = async ({
     chainId,
@@ -223,13 +223,13 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     chainId: string;
     codeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       unregister: {
         chain_id: chainId,
         code_id: codeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     admin,
@@ -237,12 +237,12 @@ export class CwCodeIdRegistryClient extends CwCodeIdRegistryQueryClient implemen
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         admin,
         payment_info: paymentInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
+++ b/__output__/daodao/cw-code-id-registry/CwCodeIdRegistry.message-composer.ts
@@ -20,7 +20,7 @@ export interface CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   register: ({
     chainId,
     checksum,
@@ -33,7 +33,7 @@ export interface CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setOwner: ({
     chainId,
     name,
@@ -42,21 +42,21 @@ export interface CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   unregister: ({
     chainId,
     codeId
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     admin,
     paymentInfo
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   sender: string;
@@ -78,7 +78,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -91,7 +91,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             sender
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -107,7 +107,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     codeId: number;
     name: string;
     version: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -122,7 +122,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             version
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -134,7 +134,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
     chainId: string;
     name: string;
     owner?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,7 +147,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             owner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -157,7 +157,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     chainId: string;
     codeId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             code_id: codeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
   }: {
     admin?: string;
     paymentInfo?: PaymentInfo;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class CwCodeIdRegistryMsgComposer implements CwCodeIdRegistryMsg {
             payment_info: paymentInfo
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
@@ -145,7 +145,7 @@ export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwN
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
@@ -158,7 +158,7 @@ export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwN
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
@@ -169,7 +169,7 @@ export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwN
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.client.ts
@@ -112,17 +112,17 @@ export interface CwNamedGroupsInterface extends CwNamedGroupsReadOnlyInterface {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwNamedGroupsInterface {
   client: SigningCosmWasmClient;
@@ -145,35 +145,35 @@ export class CwNamedGroupsClient extends CwNamedGroupsQueryClient implements CwN
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
+++ b/__output__/daodao/cw-named-groups/CwNamedGroups.message-composer.ts
@@ -20,17 +20,17 @@ export interface CwNamedGroupsMsg {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
   sender: string;
@@ -50,7 +50,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -63,7 +63,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
             group
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -71,7 +71,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
     group
   }: {
     group: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,7 +82,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
             group
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -90,7 +90,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
     owner
   }: {
     owner: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -101,7 +101,7 @@ export class CwNamedGroupsMsgComposer implements CwNamedGroupsMsg {
             owner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
@@ -174,24 +174,24 @@ export interface CwProposalSingleInterface extends CwProposalSingleReadOnlyInter
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -208,27 +208,27 @@ export interface CwProposalSingleInterface extends CwProposalSingleReadOnlyInter
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwProposalSingleClient extends CwProposalSingleQueryClient implements CwProposalSingleInterface {
   client: SigningCosmWasmClient;
@@ -257,14 +257,14 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -272,35 +272,35 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -318,7 +318,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -329,50 +329,50 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.client.ts
@@ -257,7 +257,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -272,7 +272,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -284,7 +284,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -295,7 +295,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -318,7 +318,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -335,7 +335,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -346,7 +346,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -357,7 +357,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -368,7 +368,7 @@ export class CwProposalSingleClient extends CwProposalSingleQueryClient implemen
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
+++ b/__output__/daodao/cw-proposal-single/CwProposalSingle.message-composer.ts
@@ -19,24 +19,24 @@ export interface CwProposalSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -53,27 +53,27 @@ export interface CwProposalSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
   sender: string;
@@ -99,7 +99,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     description: string;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             title
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -122,7 +122,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -134,7 +134,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             vote
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -142,7 +142,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -153,7 +153,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -161,7 +161,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -172,7 +172,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -192,7 +192,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -209,7 +209,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             threshold
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -217,7 +217,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -228,7 +228,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -236,7 +236,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -247,7 +247,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -255,7 +255,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -266,7 +266,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -274,7 +274,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
     address
   }: {
     address: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -285,7 +285,7 @@ export class CwProposalSingleMsgComposer implements CwProposalSingleMsg {
             address
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/idl-version/accounts-nft/AccountsNft.client.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.client.ts
@@ -376,14 +376,14 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     newOwner
   }: {
     newOwner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         new_owner: newOwner
       }
     }, fee_, memo_, funds_);
   };
-  acceptOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  acceptOwnership = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       accept_ownership: {}
     }, fee_, memo_, funds_);
@@ -392,7 +392,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     user
   }: {
     user: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         user
@@ -405,7 +405,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -421,7 +421,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -438,7 +438,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -453,7 +453,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -467,7 +467,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -479,7 +479,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -490,7 +490,7 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/__output__/idl-version/accounts-nft/AccountsNft.client.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.client.ts
@@ -295,20 +295,20 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     newOwner
   }: {
     newOwner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  acceptOwnership: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  acceptOwnership: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     user
   }: {
     user: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -317,7 +317,7 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -326,31 +326,31 @@ export interface AccountsNftInterface extends AccountsNftReadOnlyInterface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class AccountsNftClient extends AccountsNftQueryClient implements AccountsNftInterface {
   client: SigningCosmWasmClient;
@@ -376,28 +376,28 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     newOwner
   }: {
     newOwner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         new_owner: newOwner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  acceptOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  acceptOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       accept_ownership: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     user
   }: {
     user: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         user
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   transferNft = async ({
     recipient,
@@ -405,13 +405,13 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -421,14 +421,14 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -438,14 +438,14 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -453,13 +453,13 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -467,34 +467,34 @@ export class AccountsNftClient extends AccountsNftQueryClient implements Account
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
+++ b/__output__/idl-version/accounts-nft/AccountsNft.message-composer.ts
@@ -16,20 +16,20 @@ export interface AccountsNftMsg {
     newOwner
   }: {
     newOwner: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  acceptOwnership: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  acceptOwnership: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     user
   }: {
     user: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -38,7 +38,7 @@ export interface AccountsNftMsg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -47,31 +47,31 @@ export interface AccountsNftMsg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class AccountsNftMsgComposer implements AccountsNftMsg {
   sender: string;
@@ -94,7 +94,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     newOwner
   }: {
     newOwner: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -105,11 +105,11 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             new_owner: newOwner
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  acceptOwnership = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  acceptOwnership = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -118,7 +118,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
         msg: toUtf8(JSON.stringify({
           accept_ownership: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -126,7 +126,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     user
   }: {
     user: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -137,7 +137,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             user
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -147,7 +147,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -159,7 +159,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -171,7 +171,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -184,7 +184,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -196,7 +196,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -209,7 +209,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -219,7 +219,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -231,7 +231,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -241,7 +241,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -253,7 +253,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -261,7 +261,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -272,7 +272,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -280,7 +280,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -291,7 +291,7 @@ export class AccountsNftMsgComposer implements AccountsNftMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
@@ -230,7 +230,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -246,7 +246,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -258,7 +258,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -269,7 +269,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.client.ts
@@ -187,24 +187,24 @@ export interface Cw3FixedMultiSigInterface extends Cw3FixedMultiSigReadOnlyInter
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implements Cw3FixedMultiSigInterface {
   client: SigningCosmWasmClient;
@@ -230,7 +230,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -238,7 +238,7 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -246,34 +246,34 @@ export class Cw3FixedMultiSigClient extends Cw3FixedMultiSigQueryClient implemen
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
+++ b/__output__/idl-version/cw3-fixed-multisig/Cw3FixedMultiSig.message-composer.ts
@@ -21,24 +21,24 @@ export interface Cw3FixedMultiSigMsg {
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
   sender: string;
@@ -61,7 +61,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
     latest?: Expiration;
     msgs: CosmosMsgForEmpty[];
     title: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -75,7 +75,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
             title
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -85,7 +85,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
   }: {
     proposalId: number;
     vote: Vote;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -97,7 +97,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
             vote
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -105,7 +105,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -116,7 +116,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -124,7 +124,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
     proposalId
   }: {
     proposalId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -135,7 +135,7 @@ export class Cw3FixedMultiSigMsgComposer implements Cw3FixedMultiSigMsg {
             proposal_id: proposalId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/idl-version/cw4-group/Cw4Group.client.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.client.ts
@@ -90,24 +90,24 @@ export interface Cw4GroupInterface extends Cw4GroupReadOnlyInterface {
     admin
   }: {
     admin?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateMembers: ({
     add,
     remove
   }: {
     add: Member[];
     remove: string[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addHook: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeHook: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInterface {
   client: SigningCosmWasmClient;
@@ -127,12 +127,12 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
     admin
   }: {
     admin?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         admin
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateMembers = async ({
     add,
@@ -140,34 +140,34 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
   }: {
     add: Member[];
     remove: string[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_members: {
         add,
         remove
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addHook = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_hook: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeHook = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_hook: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/idl-version/cw4-group/Cw4Group.client.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.client.ts
@@ -127,7 +127,7 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
     admin
   }: {
     admin?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         admin
@@ -140,7 +140,7 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
   }: {
     add: Member[];
     remove: string[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_members: {
         add,
@@ -152,7 +152,7 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_hook: {
         addr
@@ -163,7 +163,7 @@ export class Cw4GroupClient extends Cw4GroupQueryClient implements Cw4GroupInter
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_hook: {
         addr

--- a/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
+++ b/__output__/idl-version/cw4-group/Cw4Group.message-composer.ts
@@ -16,24 +16,24 @@ export interface Cw4GroupMsg {
     admin
   }: {
     admin?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateMembers: ({
     add,
     remove
   }: {
     add: Member[];
     remove: string[];
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addHook: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeHook: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Cw4GroupMsgComposer implements Cw4GroupMsg {
   sender: string;
@@ -50,7 +50,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
     admin
   }: {
     admin?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -61,7 +61,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
             admin
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -71,7 +71,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
   }: {
     add: Member[];
     remove: string[];
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -83,7 +83,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
             remove
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -91,7 +91,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -102,7 +102,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -110,7 +110,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -121,7 +121,7 @@ export class Cw4GroupMsgComposer implements Cw4GroupMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/idl-version/cyberpunk/CyberPunk.client.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.client.ts
@@ -55,7 +55,7 @@ export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkIn
   }: {
     memCost: number;
     timeCost: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       argon2: {
         mem_cost: memCost,
@@ -63,7 +63,7 @@ export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkIn
       }
     }, fee_, memo_, funds_);
   };
-  mirrorEnv = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mirrorEnv = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mirror_env: {}
     }, fee_, memo_, funds_);

--- a/__output__/idl-version/cyberpunk/CyberPunk.client.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.client.ts
@@ -34,8 +34,8 @@ export interface CyberPunkInterface extends CyberPunkReadOnlyInterface {
   }: {
     memCost: number;
     timeCost: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  mirrorEnv: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  mirrorEnv: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkInterface {
   client: SigningCosmWasmClient;
@@ -55,17 +55,17 @@ export class CyberPunkClient extends CyberPunkQueryClient implements CyberPunkIn
   }: {
     memCost: number;
     timeCost: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       argon2: {
         mem_cost: memCost,
         time_cost: timeCost
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  mirrorEnv = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mirrorEnv = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mirror_env: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
+++ b/__output__/idl-version/cyberpunk/CyberPunk.message-composer.ts
@@ -18,8 +18,8 @@ export interface CyberPunkMsg {
   }: {
     memCost: number;
     timeCost: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  mirrorEnv: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  mirrorEnv: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class CyberPunkMsgComposer implements CyberPunkMsg {
   sender: string;
@@ -36,7 +36,7 @@ export class CyberPunkMsgComposer implements CyberPunkMsg {
   }: {
     memCost: number;
     timeCost: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -48,11 +48,11 @@ export class CyberPunkMsgComposer implements CyberPunkMsg {
             time_cost: timeCost
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  mirrorEnv = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mirrorEnv = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -61,7 +61,7 @@ export class CyberPunkMsgComposer implements CyberPunkMsg {
         msg: toUtf8(JSON.stringify({
           mirror_env: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/idl-version/hackatom/HackAtom.client.ts
+++ b/__output__/idl-version/hackatom/HackAtom.client.ts
@@ -105,27 +105,27 @@ export class HackAtomClient extends HackAtomQueryClient implements HackAtomInter
     this.panic = this.panic.bind(this);
     this.userErrorsInApiCalls = this.userErrorsInApiCalls.bind(this);
   }
-  release = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  release = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       release: {}
     }, fee_, memo_, funds_);
   };
-  cpuLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  cpuLoop = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cpu_loop: {}
     }, fee_, memo_, funds_);
   };
-  storageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  storageLoop = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       storage_loop: {}
     }, fee_, memo_, funds_);
   };
-  memoryLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  memoryLoop = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       memory_loop: {}
     }, fee_, memo_, funds_);
   };
-  messageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  messageLoop = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       message_loop: {}
     }, fee_, memo_, funds_);
@@ -134,19 +134,19 @@ export class HackAtomClient extends HackAtomQueryClient implements HackAtomInter
     pages
   }: {
     pages: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allocate_large_memory: {
         pages
       }
     }, fee_, memo_, funds_);
   };
-  panic = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  panic = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       panic: {}
     }, fee_, memo_, funds_);
   };
-  userErrorsInApiCalls = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  userErrorsInApiCalls = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       user_errors_in_api_calls: {}
     }, fee_, memo_, funds_);

--- a/__output__/idl-version/hackatom/HackAtom.client.ts
+++ b/__output__/idl-version/hackatom/HackAtom.client.ts
@@ -74,18 +74,18 @@ export class HackAtomQueryClient implements HackAtomReadOnlyInterface {
 export interface HackAtomInterface extends HackAtomReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  release: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  cpuLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  storageLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  memoryLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  messageLoop: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  release: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  cpuLoop: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  storageLoop: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  memoryLoop: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  messageLoop: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allocateLargeMemory: ({
     pages
   }: {
     pages: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  panic: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  userErrorsInApiCalls: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  panic: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  userErrorsInApiCalls: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class HackAtomClient extends HackAtomQueryClient implements HackAtomInterface {
   client: SigningCosmWasmClient;
@@ -105,50 +105,50 @@ export class HackAtomClient extends HackAtomQueryClient implements HackAtomInter
     this.panic = this.panic.bind(this);
     this.userErrorsInApiCalls = this.userErrorsInApiCalls.bind(this);
   }
-  release = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  release = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       release: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  cpuLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  cpuLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cpu_loop: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  storageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  storageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       storage_loop: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  memoryLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  memoryLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       memory_loop: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  messageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  messageLoop = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       message_loop: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allocateLargeMemory = async ({
     pages
   }: {
     pages: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allocate_large_memory: {
         pages
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  panic = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  panic = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       panic: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  userErrorsInApiCalls = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  userErrorsInApiCalls = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       user_errors_in_api_calls: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/idl-version/hackatom/HackAtom.message-composer.ts
+++ b/__output__/idl-version/hackatom/HackAtom.message-composer.ts
@@ -11,18 +11,18 @@ import { InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, SudoMsg, Uint128, Coi
 export interface HackAtomMsg {
   contractAddress: string;
   sender: string;
-  release: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  cpuLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  storageLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  memoryLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  messageLoop: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  release: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  cpuLoop: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  storageLoop: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  memoryLoop: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  messageLoop: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   allocateLargeMemory: ({
     pages
   }: {
     pages: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  panic: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  userErrorsInApiCalls: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  panic: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  userErrorsInApiCalls: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class HackAtomMsgComposer implements HackAtomMsg {
   sender: string;
@@ -39,7 +39,7 @@ export class HackAtomMsgComposer implements HackAtomMsg {
     this.panic = this.panic.bind(this);
     this.userErrorsInApiCalls = this.userErrorsInApiCalls.bind(this);
   }
-  release = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  release = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -48,11 +48,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           release: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  cpuLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  cpuLoop = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -61,11 +61,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           cpu_loop: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  storageLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  storageLoop = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -74,11 +74,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           storage_loop: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  memoryLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  memoryLoop = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -87,11 +87,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           memory_loop: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  messageLoop = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  messageLoop = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -100,7 +100,7 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           message_loop: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -108,7 +108,7 @@ export class HackAtomMsgComposer implements HackAtomMsg {
     pages
   }: {
     pages: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -119,11 +119,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
             pages
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  panic = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  panic = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -132,11 +132,11 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           panic: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  userErrorsInApiCalls = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  userErrorsInApiCalls = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -145,7 +145,7 @@ export class HackAtomMsgComposer implements HackAtomMsg {
         msg: toUtf8(JSON.stringify({
           user_errors_in_api_calls: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/minter/Minter.client.ts
+++ b/__output__/minter/Minter.client.ts
@@ -66,31 +66,31 @@ export class MinterQueryClient implements MinterReadOnlyInterface {
 export interface MinterInterface extends MinterReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  mint: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  mint: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  withdraw: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  withdraw: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class MinterClient extends MinterQueryClient implements MinterInterface {
   client: SigningCosmWasmClient;
@@ -109,48 +109,48 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWhitelist = async ({
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePerAddressLimit = async ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintTo = async ({
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mintFor = async ({
     recipient,
@@ -158,17 +158,17 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/minter/Minter.client.ts
+++ b/__output__/minter/Minter.client.ts
@@ -109,7 +109,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  mint = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {}
     }, fee_, memo_, funds_);
@@ -118,14 +118,14 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     whitelist
   }: {
     whitelist: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_whitelist: {
         whitelist
       }
     }, fee_, memo_, funds_);
   };
-  updateStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_start_time: {}
     }, fee_, memo_, funds_);
@@ -134,7 +134,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_per_address_limit: {
         per_address_limit: perAddressLimit
@@ -145,7 +145,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
     recipient
   }: {
     recipient: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_to: {
         recipient
@@ -158,7 +158,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
   }: {
     recipient: string;
     tokenId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint_for: {
         recipient,
@@ -166,7 +166,7 @@ export class MinterClient extends MinterQueryClient implements MinterInterface {
       }
     }, fee_, memo_, funds_);
   };
-  withdraw = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  withdraw = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       withdraw: {}
     }, fee_, memo_, funds_);

--- a/__output__/minter/Minter.message-composer.ts
+++ b/__output__/minter/Minter.message-composer.ts
@@ -11,31 +11,31 @@ import { Timestamp, Uint64, Uint128, ConfigResponse, Coin, Addr, Config, Execute
 export interface MinterMsg {
   contractAddress: string;
   sender: string;
-  mint: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  mint: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   setWhitelist: ({
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateStartTime: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updatePerAddressLimit: ({
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintTo: ({
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mintFor: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  withdraw: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  withdraw: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class MinterMsgComposer implements MinterMsg {
   sender: string;
@@ -51,7 +51,7 @@ export class MinterMsgComposer implements MinterMsg {
     this.mintFor = this.mintFor.bind(this);
     this.withdraw = this.withdraw.bind(this);
   }
-  mint = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  mint = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -60,7 +60,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           mint: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -68,7 +68,7 @@ export class MinterMsgComposer implements MinterMsg {
     whitelist
   }: {
     whitelist: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -79,11 +79,11 @@ export class MinterMsgComposer implements MinterMsg {
             whitelist
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateStartTime = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -92,7 +92,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           update_start_time: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -100,7 +100,7 @@ export class MinterMsgComposer implements MinterMsg {
     perAddressLimit
   }: {
     perAddressLimit: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -111,7 +111,7 @@ export class MinterMsgComposer implements MinterMsg {
             per_address_limit: perAddressLimit
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -119,7 +119,7 @@ export class MinterMsgComposer implements MinterMsg {
     recipient
   }: {
     recipient: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -130,7 +130,7 @@ export class MinterMsgComposer implements MinterMsg {
             recipient
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -140,7 +140,7 @@ export class MinterMsgComposer implements MinterMsg {
   }: {
     recipient: string;
     tokenId: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -152,11 +152,11 @@ export class MinterMsgComposer implements MinterMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  withdraw = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  withdraw = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -165,7 +165,7 @@ export class MinterMsgComposer implements MinterMsg {
         msg: toUtf8(JSON.stringify({
           withdraw: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/sg721-updatable/Sg721Updatable.client.ts
+++ b/__output__/sg721-updatable/Sg721Updatable.client.ts
@@ -240,22 +240,22 @@ export class Sg721UpdatableQueryClient implements Sg721UpdatableReadOnlyInterfac
 export interface Sg721UpdatableInterface extends Sg721UpdatableReadOnlyInterface {
   contractAddress: string;
   sender: string;
-  freezeTokenMetadata: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  freezeTokenMetadata: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateTokenMetadata: ({
     tokenId,
     tokenUri
   }: {
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  enableUpdatable: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  enableUpdatable: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -264,7 +264,7 @@ export interface Sg721UpdatableInterface extends Sg721UpdatableReadOnlyInterface
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -273,38 +273,38 @@ export interface Sg721UpdatableInterface extends Sg721UpdatableReadOnlyInterface
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCollectionInfo: ({
     collectionInfo
   }: {
     collectionInfo: UpdateCollectionInfoMsgForRoyaltyInfoResponse;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateTradingStartTime: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  freezeCollectionInfo: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateTradingStartTime: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  freezeCollectionInfo: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -315,12 +315,12 @@ export interface Sg721UpdatableInterface extends Sg721UpdatableReadOnlyInterface
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   extension: ({
     msg
   }: {
     msg: Empty;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements Sg721UpdatableInterface {
   client: SigningCosmWasmClient;
@@ -347,10 +347,10 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     this.mint = this.mint.bind(this);
     this.extension = this.extension.bind(this);
   }
-  freezeTokenMetadata = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  freezeTokenMetadata = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       freeze_token_metadata: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateTokenMetadata = async ({
     tokenId,
@@ -358,18 +358,18 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_token_metadata: {
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  enableUpdatable = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  enableUpdatable = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       enable_updatable: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   transferNft = async ({
     recipient,
@@ -377,13 +377,13 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -393,14 +393,14 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -410,14 +410,14 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -425,13 +425,13 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -439,56 +439,56 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCollectionInfo = async ({
     collectionInfo
   }: {
     collectionInfo: UpdateCollectionInfoMsgForRoyaltyInfoResponse;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_collection_info: {
         collection_info: collectionInfo
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateTradingStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateTradingStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_trading_start_time: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  freezeCollectionInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  freezeCollectionInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       freeze_collection_info: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -500,7 +500,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -508,17 +508,17 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   extension = async ({
     msg
   }: {
     msg: Empty;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       extension: {
         msg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/sg721-updatable/Sg721Updatable.client.ts
+++ b/__output__/sg721-updatable/Sg721Updatable.client.ts
@@ -347,7 +347,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     this.mint = this.mint.bind(this);
     this.extension = this.extension.bind(this);
   }
-  freezeTokenMetadata = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  freezeTokenMetadata = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       freeze_token_metadata: {}
     }, fee_, memo_, funds_);
@@ -358,7 +358,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_token_metadata: {
         token_id: tokenId,
@@ -366,7 +366,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
       }
     }, fee_, memo_, funds_);
   };
-  enableUpdatable = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  enableUpdatable = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       enable_updatable: {}
     }, fee_, memo_, funds_);
@@ -377,7 +377,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -393,7 +393,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -410,7 +410,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -425,7 +425,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -439,7 +439,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -451,7 +451,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -462,7 +462,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -473,19 +473,19 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     collectionInfo
   }: {
     collectionInfo: UpdateCollectionInfoMsgForRoyaltyInfoResponse;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_collection_info: {
         collection_info: collectionInfo
       }
     }, fee_, memo_, funds_);
   };
-  updateTradingStartTime = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateTradingStartTime = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_trading_start_time: {}
     }, fee_, memo_, funds_);
   };
-  freezeCollectionInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  freezeCollectionInfo = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       freeze_collection_info: {}
     }, fee_, memo_, funds_);
@@ -500,7 +500,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -514,7 +514,7 @@ export class Sg721UpdatableClient extends Sg721UpdatableQueryClient implements S
     msg
   }: {
     msg: Empty;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       extension: {
         msg

--- a/__output__/sg721-updatable/Sg721Updatable.message-composer.ts
+++ b/__output__/sg721-updatable/Sg721Updatable.message-composer.ts
@@ -12,22 +12,22 @@ import { Expiration, Timestamp, Uint64, AllNftInfoResponse, OwnerOfResponse, App
 export interface Sg721UpdatableMsg {
   contractAddress: string;
   sender: string;
-  freezeTokenMetadata: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  freezeTokenMetadata: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateTokenMetadata: ({
     tokenId,
     tokenUri
   }: {
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  enableUpdatable: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  enableUpdatable: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   transferNft: ({
     recipient,
     tokenId
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -36,7 +36,7 @@ export interface Sg721UpdatableMsg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -45,38 +45,38 @@ export interface Sg721UpdatableMsg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCollectionInfo: ({
     collectionInfo
   }: {
     collectionInfo: UpdateCollectionInfoMsgForRoyaltyInfoResponse;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateTradingStartTime: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  freezeCollectionInfo: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateTradingStartTime: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  freezeCollectionInfo: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     extension,
     owner,
@@ -87,12 +87,12 @@ export interface Sg721UpdatableMsg {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   extension: ({
     msg
   }: {
     msg: Empty;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
   sender: string;
@@ -116,7 +116,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     this.mint = this.mint.bind(this);
     this.extension = this.extension.bind(this);
   }
-  freezeTokenMetadata = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  freezeTokenMetadata = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -125,7 +125,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
         msg: toUtf8(JSON.stringify({
           freeze_token_metadata: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -135,7 +135,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
   }: {
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -147,11 +147,11 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_uri: tokenUri
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  enableUpdatable = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  enableUpdatable = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -160,7 +160,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
         msg: toUtf8(JSON.stringify({
           enable_updatable: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -170,7 +170,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -182,7 +182,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -194,7 +194,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -207,7 +207,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -219,7 +219,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -232,7 +232,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -242,7 +242,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -254,7 +254,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -264,7 +264,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -276,7 +276,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -284,7 +284,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -295,7 +295,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -303,7 +303,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -314,7 +314,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -322,7 +322,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     collectionInfo
   }: {
     collectionInfo: UpdateCollectionInfoMsgForRoyaltyInfoResponse;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -333,11 +333,11 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             collection_info: collectionInfo
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateTradingStartTime = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateTradingStartTime = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -346,11 +346,11 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
         msg: toUtf8(JSON.stringify({
           update_trading_start_time: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  freezeCollectionInfo = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  freezeCollectionInfo = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -359,7 +359,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
         msg: toUtf8(JSON.stringify({
           freeze_collection_info: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -373,7 +373,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -387,7 +387,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             token_uri: tokenUri
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -395,7 +395,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
     msg
   }: {
     msg: Empty;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -406,7 +406,7 @@ export class Sg721UpdatableMsgComposer implements Sg721UpdatableMsg {
             msg
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/sg721/Sg721.client.ts
+++ b/__output__/sg721/Sg721.client.ts
@@ -325,7 +325,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -341,7 +341,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -358,7 +358,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -373,7 +373,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -387,7 +387,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -399,7 +399,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -416,7 +416,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -430,7 +430,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/__output__/sg721/Sg721.client.ts
+++ b/__output__/sg721/Sg721.client.ts
@@ -246,7 +246,7 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -255,7 +255,7 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -264,26 +264,26 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -294,12 +294,12 @@ export interface Sg721Interface extends Sg721ReadOnlyInterface {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   client: SigningCosmWasmClient;
@@ -325,13 +325,13 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -341,14 +341,14 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -358,14 +358,14 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -373,13 +373,13 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -387,24 +387,24 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -416,7 +416,7 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -424,17 +424,17 @@ export class Sg721Client extends Sg721QueryClient implements Sg721Interface {
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/sg721/Sg721.message-composer.ts
+++ b/__output__/sg721/Sg721.message-composer.ts
@@ -18,7 +18,7 @@ export interface Sg721Msg {
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -27,7 +27,7 @@ export interface Sg721Msg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -36,26 +36,26 @@ export interface Sg721Msg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     extension,
     owner,
@@ -66,12 +66,12 @@ export interface Sg721Msg {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class Sg721MsgComposer implements Sg721Msg {
   sender: string;
@@ -94,7 +94,7 @@ export class Sg721MsgComposer implements Sg721Msg {
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -106,7 +106,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -118,7 +118,7 @@ export class Sg721MsgComposer implements Sg721Msg {
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -131,7 +131,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -143,7 +143,7 @@ export class Sg721MsgComposer implements Sg721Msg {
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -156,7 +156,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -166,7 +166,7 @@ export class Sg721MsgComposer implements Sg721Msg {
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -178,7 +178,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -188,7 +188,7 @@ export class Sg721MsgComposer implements Sg721Msg {
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -200,7 +200,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -208,7 +208,7 @@ export class Sg721MsgComposer implements Sg721Msg {
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -219,7 +219,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -233,7 +233,7 @@ export class Sg721MsgComposer implements Sg721Msg {
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -247,7 +247,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_uri: tokenUri
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -255,7 +255,7 @@ export class Sg721MsgComposer implements Sg721Msg {
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -266,7 +266,7 @@ export class Sg721MsgComposer implements Sg721Msg {
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/vectis/factory/Factory.client.ts
+++ b/__output__/vectis/factory/Factory.client.ts
@@ -171,7 +171,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
@@ -184,7 +184,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
@@ -198,7 +198,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
@@ -212,7 +212,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
@@ -224,7 +224,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
@@ -235,7 +235,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
@@ -246,7 +246,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr

--- a/__output__/vectis/factory/Factory.client.ts
+++ b/__output__/vectis/factory/Factory.client.ts
@@ -112,43 +112,43 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class FactoryClient extends FactoryQueryClient implements FactoryInterface {
   client: SigningCosmWasmClient;
@@ -171,12 +171,12 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_wallet: {
         create_wallet_msg: createWalletMsg
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateProxyUser = async ({
     newUser,
@@ -184,13 +184,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_proxy_user: {
         new_user: newUser,
         old_user: oldUser
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   migrateWallet = async ({
     migrationMsg,
@@ -198,13 +198,13 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       migrate_wallet: {
         migration_msg: migrationMsg,
         wallet_address: walletAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateCodeId = async ({
     newCodeId,
@@ -212,45 +212,45 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_code_id: {
         new_code_id: newCodeId,
         ty
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateWalletFee = async ({
     newFee
   }: {
     newFee: Coin;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_wallet_fee: {
         new_fee: newFee
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGovecAddr = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_govec_addr: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateAdmin = async ({
     addr
   }: {
     addr: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_admin: {
         addr
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/vectis/factory/Factory.message-composer.ts
+++ b/__output__/vectis/factory/Factory.message-composer.ts
@@ -15,43 +15,43 @@ export interface FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateProxyUser: ({
     newUser,
     oldUser
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   migrateWallet: ({
     migrationMsg,
     walletAddress
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateCodeId: ({
     newCodeId,
     ty
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateWalletFee: ({
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGovecAddr: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateAdmin: ({
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class FactoryMsgComposer implements FactoryMsg {
   sender: string;
@@ -71,7 +71,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     createWalletMsg
   }: {
     createWalletMsg: CreateWalletMsg;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -82,7 +82,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             create_wallet_msg: createWalletMsg
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -92,7 +92,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newUser: Addr;
     oldUser: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -104,7 +104,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             old_user: oldUser
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -114,7 +114,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     migrationMsg: ProxyMigrationTxMsg;
     walletAddress: WalletAddr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -126,7 +126,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             wallet_address: walletAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -136,7 +136,7 @@ export class FactoryMsgComposer implements FactoryMsg {
   }: {
     newCodeId: number;
     ty: CodeIdType;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -148,7 +148,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             ty
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -156,7 +156,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     newFee
   }: {
     newFee: Coin;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -167,7 +167,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             new_fee: newFee
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -175,7 +175,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -186,7 +186,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -194,7 +194,7 @@ export class FactoryMsgComposer implements FactoryMsg {
     addr
   }: {
     addr: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -205,7 +205,7 @@ export class FactoryMsgComposer implements FactoryMsg {
             addr
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/vectis/govec/Govec.client.ts
+++ b/__output__/vectis/govec/Govec.client.ts
@@ -49,40 +49,40 @@ export interface GovecInterface extends GovecReadOnlyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class GovecClient extends GovecQueryClient implements GovecInterface {
   client: SigningCosmWasmClient;
@@ -106,61 +106,61 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGuardians = async ({
     guardians,
@@ -168,23 +168,23 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/vectis/govec/Govec.client.ts
+++ b/__output__/vectis/govec/Govec.client.ts
@@ -106,14 +106,14 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
     }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
     }, fee_, memo_, funds_);
@@ -122,7 +122,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
@@ -133,7 +133,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
@@ -144,7 +144,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
@@ -155,7 +155,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
@@ -168,7 +168,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
@@ -180,7 +180,7 @@ export class GovecClient extends GovecQueryClient implements GovecInterface {
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel

--- a/__output__/vectis/govec/Govec.message-composer.ts
+++ b/__output__/vectis/govec/Govec.message-composer.ts
@@ -15,40 +15,40 @@ export interface GovecMsg {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  revertFreezeStatus: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  revertFreezeStatus: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class GovecMsgComposer implements GovecMsg {
   sender: string;
@@ -69,7 +69,7 @@ export class GovecMsgComposer implements GovecMsg {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -80,11 +80,11 @@ export class GovecMsgComposer implements GovecMsg {
             msgs
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  revertFreezeStatus = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  revertFreezeStatus = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class GovecMsgComposer implements GovecMsg {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -101,7 +101,7 @@ export class GovecMsgComposer implements GovecMsg {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class GovecMsgComposer implements GovecMsg {
             transaction
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -120,7 +120,7 @@ export class GovecMsgComposer implements GovecMsg {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -131,7 +131,7 @@ export class GovecMsgComposer implements GovecMsg {
             new_user_address: newUserAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -139,7 +139,7 @@ export class GovecMsgComposer implements GovecMsg {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class GovecMsgComposer implements GovecMsg {
             new_relayer_address: newRelayerAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -158,7 +158,7 @@ export class GovecMsgComposer implements GovecMsg {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class GovecMsgComposer implements GovecMsg {
             relayer_address: relayerAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class GovecMsgComposer implements GovecMsg {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class GovecMsgComposer implements GovecMsg {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -199,7 +199,7 @@ export class GovecMsgComposer implements GovecMsg {
     newLabel
   }: {
     newLabel: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -210,7 +210,7 @@ export class GovecMsgComposer implements GovecMsg {
             new_label: newLabel
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/__output__/vectis/proxy/Proxy.client.ts
+++ b/__output__/vectis/proxy/Proxy.client.ts
@@ -49,40 +49,40 @@ export interface ProxyInterface extends ProxyReadOnlyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }
 export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   client: SigningCosmWasmClient;
@@ -106,61 +106,61 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGuardians = async ({
     guardians,
@@ -168,23 +168,23 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }

--- a/__output__/vectis/proxy/Proxy.client.ts
+++ b/__output__/vectis/proxy/Proxy.client.ts
@@ -106,14 +106,14 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
     }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
     }, fee_, memo_, funds_);
@@ -122,7 +122,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
@@ -133,7 +133,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
@@ -144,7 +144,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
@@ -155,7 +155,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
@@ -168,7 +168,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
@@ -180,7 +180,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel

--- a/__output__/vectis/proxy/Proxy.message-composer.ts
+++ b/__output__/vectis/proxy/Proxy.message-composer.ts
@@ -15,40 +15,40 @@ export interface ProxyMsg {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  revertFreezeStatus: (_funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  revertFreezeStatus: (funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }
 export class ProxyMsgComposer implements ProxyMsg {
   sender: string;
@@ -69,7 +69,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     msgs
   }: {
     msgs: CosmosMsgForEmpty[];
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -80,11 +80,11 @@ export class ProxyMsgComposer implements ProxyMsg {
             msgs
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  revertFreezeStatus = (_funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  revertFreezeStatus = (funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -93,7 +93,7 @@ export class ProxyMsgComposer implements ProxyMsg {
         msg: toUtf8(JSON.stringify({
           revert_freeze_status: {}
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -101,7 +101,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     transaction
   }: {
     transaction: RelayTransaction;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -112,7 +112,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             transaction
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -120,7 +120,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     newUserAddress
   }: {
     newUserAddress: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -131,7 +131,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             new_user_address: newUserAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -139,7 +139,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -150,7 +150,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             new_relayer_address: newRelayerAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -158,7 +158,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -169,7 +169,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             relayer_address: relayerAddress
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -179,7 +179,7 @@ export class ProxyMsgComposer implements ProxyMsg {
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -191,7 +191,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             new_multisig_code_id: newMultisigCodeId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -199,7 +199,7 @@ export class ProxyMsgComposer implements ProxyMsg {
     newLabel
   }: {
     newLabel: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -210,7 +210,7 @@ export class ProxyMsgComposer implements ProxyMsg {
             new_label: newLabel
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
@@ -25,10 +25,10 @@ exports[`execute classes array types 1`] = `
     this.allTokens = this.allTokens.bind(this);
     this.minter = this.minter.bind(this);
   }
-  proposedNewOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  proposedNewOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proposed_new_owner: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allowedVaults = async ({
     limit,
@@ -36,13 +36,13 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allowed_vaults: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allDebtShares = async ({
     limit,
@@ -50,18 +50,18 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_debt_shares: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  allPreviousOwners = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  allPreviousOwners = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_previous_owners: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   ownerOf = async ({
     includeExpired,
@@ -69,13 +69,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       owner_of: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approval = async ({
     includeExpired,
@@ -85,14 +85,14 @@ exports[`execute classes array types 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approval: {
         include_expired: includeExpired,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approvals = async ({
     includeExpired,
@@ -100,13 +100,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approvals: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allOperators = async ({
     includeExpired,
@@ -118,7 +118,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_operators: {
         include_expired: includeExpired,
@@ -126,28 +126,28 @@ exports[`execute classes array types 1`] = `
         owner,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  numTokens = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  numTokens = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       num_tokens: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  contractInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  contractInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       contract_info: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   nftInfo = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       nft_info: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allNftInfo = async ({
     includeExpired,
@@ -155,13 +155,13 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_nft_info: {
         include_expired: includeExpired,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   tokens = async ({
     limit,
@@ -171,14 +171,14 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       tokens: {
         limit,
         owner,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   allTokens = async ({
     limit,
@@ -186,18 +186,18 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_tokens: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  minter = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  minter = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       minter: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -206,29 +206,29 @@ exports[`execute interfaces no extends 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  proposedNewOwner: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  proposedNewOwner: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allowedVaults: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allDebtShares: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  allPreviousOwners: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  allPreviousOwners: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   ownerOf: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approval: ({
     includeExpired,
     spender,
@@ -237,14 +237,14 @@ exports[`execute interfaces no extends 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approvals: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allOperators: ({
     includeExpired,
     limit,
@@ -255,21 +255,21 @@ exports[`execute interfaces no extends 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  numTokens: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  contractInfo: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  numTokens: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  contractInfo: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   nftInfo: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allNftInfo: ({
     includeExpired,
     tokenId
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   tokens: ({
     limit,
     owner,
@@ -278,15 +278,15 @@ exports[`execute interfaces no extends 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   allTokens: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  minter: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  minter: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
@@ -25,7 +25,7 @@ exports[`execute classes array types 1`] = `
     this.allTokens = this.allTokens.bind(this);
     this.minter = this.minter.bind(this);
   }
-  proposedNewOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  proposedNewOwner = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proposed_new_owner: {}
     }, fee_, memo_, funds_);
@@ -36,7 +36,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allowed_vaults: {
         limit,
@@ -50,7 +50,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_debt_shares: {
         limit,
@@ -58,7 +58,7 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  allPreviousOwners = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  allPreviousOwners = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_previous_owners: {}
     }, fee_, memo_, funds_);
@@ -69,7 +69,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       owner_of: {
         include_expired: includeExpired,
@@ -85,7 +85,7 @@ exports[`execute classes array types 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approval: {
         include_expired: includeExpired,
@@ -100,7 +100,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approvals: {
         include_expired: includeExpired,
@@ -118,7 +118,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_operators: {
         include_expired: includeExpired,
@@ -128,12 +128,12 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  numTokens = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  numTokens = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       num_tokens: {}
     }, fee_, memo_, funds_);
   };
-  contractInfo = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  contractInfo = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       contract_info: {}
     }, fee_, memo_, funds_);
@@ -142,7 +142,7 @@ exports[`execute classes array types 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       nft_info: {
         token_id: tokenId
@@ -155,7 +155,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_nft_info: {
         include_expired: includeExpired,
@@ -171,7 +171,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       tokens: {
         limit,
@@ -186,7 +186,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_tokens: {
         limit,
@@ -194,7 +194,7 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  minter = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  minter = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       minter: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.account-nfts.test.ts.snap
@@ -25,7 +25,7 @@ exports[`execute classes array types 1`] = `
     this.allTokens = this.allTokens.bind(this);
     this.minter = this.minter.bind(this);
   }
-  proposedNewOwner = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  proposedNewOwner = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       proposed_new_owner: {}
     }, fee_, memo_, funds_);
@@ -36,7 +36,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: VaultBase_for_String;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       allowed_vaults: {
         limit,
@@ -50,7 +50,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_debt_shares: {
         limit,
@@ -58,7 +58,7 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  allPreviousOwners = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  allPreviousOwners = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_previous_owners: {}
     }, fee_, memo_, funds_);
@@ -69,7 +69,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       owner_of: {
         include_expired: includeExpired,
@@ -85,7 +85,7 @@ exports[`execute classes array types 1`] = `
     includeExpired?: boolean;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approval: {
         include_expired: includeExpired,
@@ -100,7 +100,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approvals: {
         include_expired: includeExpired,
@@ -118,7 +118,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_operators: {
         include_expired: includeExpired,
@@ -128,12 +128,12 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  numTokens = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  numTokens = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       num_tokens: {}
     }, fee_, memo_, funds_);
   };
-  contractInfo = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  contractInfo = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       contract_info: {}
     }, fee_, memo_, funds_);
@@ -142,7 +142,7 @@ exports[`execute classes array types 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       nft_info: {
         token_id: tokenId
@@ -155,7 +155,7 @@ exports[`execute classes array types 1`] = `
   }: {
     includeExpired?: boolean;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_nft_info: {
         include_expired: includeExpired,
@@ -171,7 +171,7 @@ exports[`execute classes array types 1`] = `
     limit?: number;
     owner: string;
     startAfter?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       tokens: {
         limit,
@@ -186,7 +186,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_tokens: {
         limit,
@@ -194,7 +194,7 @@ exports[`execute classes array types 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  minter = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  minter = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       minter: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,
@@ -32,7 +32,7 @@ exports[`execute classes array types 1`] = `
         nested,
         supernested
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -53,7 +53,7 @@ exports[`execute interfaces no extends 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-item-tuples.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
@@ -30,7 +30,7 @@ exports[`execute classes array types 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
@@ -46,7 +46,7 @@ exports[`execute classes array types 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
@@ -59,7 +59,7 @@ exports[`execute classes array types 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
@@ -70,7 +70,7 @@ exports[`execute classes array types 1`] = `
     graph
   }: {
     graph: Edge[];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
@@ -83,7 +83,7 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
@@ -97,7 +97,7 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
@@ -109,7 +109,7 @@ exports[`execute classes array types 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
@@ -120,14 +120,14 @@ exports[`execute classes array types 1`] = `
     edges
   }: {
     edges: number[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
     }, fee_, memo_, funds_);
   };
-  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
     }, fee_, memo_, funds_);
@@ -136,14 +136,14 @@ exports[`execute classes array types 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  reset = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
     }, fee_, memo_, funds_);
@@ -152,7 +152,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
@@ -163,7 +163,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
@@ -174,7 +174,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
@@ -30,13 +30,13 @@ exports[`execute classes array types 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
         creditor
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   editEdge = async ({
     amount,
@@ -46,36 +46,36 @@ exports[`execute classes array types 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
         creditor,
         edge_id: edgeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraph = async ({
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraphSimplified = async ({
     graph,
@@ -83,13 +83,13 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   editGraphSimplified = async ({
     graph,
@@ -97,89 +97,89 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateEdges = async ({
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   findSavingsInAGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   saveNetworkToFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraphFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   applySetOffFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -194,7 +194,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   editEdge: ({
     amount,
     creditor,
@@ -203,63 +203,63 @@ exports[`execute interfaces no extends 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraph: ({
     graph
   }: {
     graph: Edge[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   editGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateEdges: ({
     edges
   }: {
     edges: number[][];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  findSavings: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  findSavings: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   findSavingsInAGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  reset: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  reset: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   saveNetworkToFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraphFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   applySetOffFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays-ref.test.ts.snap
@@ -30,7 +30,7 @@ exports[`execute classes array types 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
@@ -46,7 +46,7 @@ exports[`execute classes array types 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
@@ -59,7 +59,7 @@ exports[`execute classes array types 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
@@ -70,7 +70,7 @@ exports[`execute classes array types 1`] = `
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
@@ -83,7 +83,7 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
@@ -97,7 +97,7 @@ exports[`execute classes array types 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
@@ -109,7 +109,7 @@ exports[`execute classes array types 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
@@ -120,14 +120,14 @@ exports[`execute classes array types 1`] = `
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
     }, fee_, memo_, funds_);
   };
-  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
     }, fee_, memo_, funds_);
@@ -136,14 +136,14 @@ exports[`execute classes array types 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
     }, fee_, memo_, funds_);
@@ -152,7 +152,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
@@ -163,7 +163,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
@@ -174,7 +174,7 @@ exports[`execute classes array types 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,
@@ -32,7 +32,7 @@ exports[`execute classes array types 1`] = `
         nested,
         supernested
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -53,7 +53,7 @@ exports[`execute interfaces no extends 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.arrays.test.ts.snap
@@ -23,7 +23,7 @@ exports[`execute classes array types 1`] = `
     edges: number[][];
     nested: number[][][];
     supernested: string[][][][][][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges3,

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
@@ -21,36 +21,36 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -67,17 +67,17 @@ exports[`execute interfaces no extends 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeGroup: ({
     group
   }: {
     group: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateOwner: ({
     owner
   }: {
     owner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
@@ -21,7 +21,7 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
@@ -34,7 +34,7 @@ exports[`execute classes array types 1`] = `
     group
   }: {
     group: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
@@ -45,7 +45,7 @@ exports[`execute classes array types 1`] = `
     owner
   }: {
     owner: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-named-groups.test.ts.snap
@@ -21,7 +21,7 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
@@ -34,7 +34,7 @@ exports[`execute classes array types 1`] = `
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
@@ -45,7 +45,7 @@ exports[`execute classes array types 1`] = `
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
@@ -27,7 +27,7 @@ exports[`execute classes array types 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -42,7 +42,7 @@ exports[`execute classes array types 1`] = `
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -54,7 +54,7 @@ exports[`execute classes array types 1`] = `
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -65,7 +65,7 @@ exports[`execute classes array types 1`] = `
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -88,7 +88,7 @@ exports[`execute classes array types 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -105,7 +105,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -116,7 +116,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -127,7 +127,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -138,7 +138,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
@@ -27,7 +27,7 @@ exports[`execute classes array types 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
@@ -42,7 +42,7 @@ exports[`execute classes array types 1`] = `
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
@@ -54,7 +54,7 @@ exports[`execute classes array types 1`] = `
     proposalId
   }: {
     proposalId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
@@ -65,7 +65,7 @@ exports[`execute classes array types 1`] = `
     proposalId
   }: {
     proposalId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
@@ -88,7 +88,7 @@ exports[`execute classes array types 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -105,7 +105,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
@@ -116,7 +116,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
@@ -127,7 +127,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
@@ -138,7 +138,7 @@ exports[`execute classes array types 1`] = `
     address
   }: {
     address: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.cw-proposal-single.test.ts.snap
@@ -27,14 +27,14 @@ exports[`execute classes array types 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose: {
         description,
         msgs,
         title
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   vote = async ({
     proposalId,
@@ -42,35 +42,35 @@ exports[`execute classes array types 1`] = `
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       vote: {
         proposal_id: proposalId,
         vote
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   execute = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   close = async ({
     proposalId
   }: {
     proposalId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       close: {
         proposal_id: proposalId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     allowRevoting,
@@ -88,7 +88,7 @@ exports[`execute classes array types 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         allow_revoting: allowRevoting,
@@ -99,51 +99,51 @@ exports[`execute classes array types 1`] = `
         only_members_execute: onlyMembersExecute,
         threshold
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeProposalHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeVoteHook = async ({
     address
   }: {
     address: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_vote_hook: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -160,24 +160,24 @@ exports[`execute interfaces no extends 1`] = `
     description: string;
     msgs: CosmosMsg_for_Empty[];
     title: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   vote: ({
     proposalId,
     vote
   }: {
     proposalId: number;
     vote: Vote;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   execute: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   close: ({
     proposalId
   }: {
     proposalId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     allowRevoting,
     dao,
@@ -194,27 +194,27 @@ exports[`execute interfaces no extends 1`] = `
     minVotingPeriod?: Duration;
     onlyMembersExecute: boolean;
     threshold: Threshold;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeProposalHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeVoteHook: ({
     address
   }: {
     address: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
@@ -25,7 +25,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -41,7 +41,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -58,7 +58,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -73,7 +73,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -87,7 +87,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -99,7 +99,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -116,7 +116,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -130,7 +130,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -164,7 +164,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -180,7 +180,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -197,7 +197,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -212,7 +212,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -226,7 +226,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -238,7 +238,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -255,7 +255,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -269,7 +269,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -304,7 +304,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -320,7 +320,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -337,7 +337,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -352,7 +352,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -366,7 +366,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -378,7 +378,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -395,7 +395,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -409,7 +409,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -444,7 +444,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -460,7 +460,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -477,7 +477,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -492,7 +492,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -506,7 +506,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -518,7 +518,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -535,7 +535,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -549,7 +549,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -583,7 +583,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -599,7 +599,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -616,7 +616,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -631,7 +631,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -645,7 +645,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -657,7 +657,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -674,7 +674,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -688,7 +688,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
@@ -25,7 +25,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -41,7 +41,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -58,7 +58,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -73,7 +73,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -87,7 +87,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -99,7 +99,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -116,7 +116,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -130,7 +130,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -164,7 +164,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -180,7 +180,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -197,7 +197,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -212,7 +212,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -226,7 +226,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -238,7 +238,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -255,7 +255,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -269,7 +269,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -304,7 +304,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -320,7 +320,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -337,7 +337,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -352,7 +352,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -366,7 +366,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -378,7 +378,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -395,7 +395,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -409,7 +409,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -444,7 +444,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -460,7 +460,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -477,7 +477,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -492,7 +492,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -506,7 +506,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -518,7 +518,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -535,7 +535,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -549,7 +549,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -583,7 +583,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -599,7 +599,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -616,7 +616,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -631,7 +631,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -645,7 +645,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -657,7 +657,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -674,7 +674,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -688,7 +688,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.declare.test.ts.snap
@@ -25,13 +25,13 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -41,14 +41,14 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -58,14 +58,14 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -73,13 +73,13 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -87,24 +87,24 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -116,7 +116,7 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -124,18 +124,18 @@ exports[`noDeclare, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -164,13 +164,13 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -180,14 +180,14 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -197,14 +197,14 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -212,13 +212,13 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -226,24 +226,24 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -255,7 +255,7 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -263,18 +263,18 @@ exports[`noDeclare, execExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -304,13 +304,13 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -320,14 +320,14 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -337,14 +337,14 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -352,13 +352,13 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -366,24 +366,24 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -395,7 +395,7 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -403,18 +403,18 @@ exports[`useDeclare, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -444,13 +444,13 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -460,14 +460,14 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -477,14 +477,14 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -492,13 +492,13 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -506,24 +506,24 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -535,7 +535,7 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -543,18 +543,18 @@ exports[`useDeclare, noExecExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -583,13 +583,13 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -599,14 +599,14 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -616,14 +616,14 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -631,13 +631,13 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -645,24 +645,24 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -674,7 +674,7 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -682,18 +682,18 @@ exports[`useDeclare, noExecExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
@@ -8,8 +8,8 @@ exports[`execute interfaces no extends 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  updateOwnership: (action: Action, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  updateOwnership: (action: Action, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 
@@ -29,17 +29,17 @@ exports[`ownership client with tuple 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_factory: {
         new_factory: newFactory
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  updateOwnership = async (action: Action, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  updateOwnership = async (action: Action, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_ownership: action
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
@@ -29,14 +29,14 @@ exports[`ownership client with tuple 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_factory: {
         new_factory: newFactory
       }
     }, fee_, memo_, funds_);
   };
-  updateOwnership = async (action: Action, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateOwnership = async (action: Action, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_ownership: action
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-101.test.ts.snap
@@ -29,14 +29,14 @@ exports[`ownership client with tuple 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_factory: {
         new_factory: newFactory
       }
     }, fee_, memo_, funds_);
   };
-  updateOwnership = async (action: Action, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  updateOwnership = async (action: Action, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_ownership: action
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
@@ -28,7 +28,7 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -45,7 +45,7 @@ exports[`execute class /execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         fee_collector: feeCollector,
@@ -62,7 +62,7 @@ exports[`execute class /execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_pool_config: {
         is_disabled: isDisabled,
@@ -75,7 +75,7 @@ exports[`execute class /execute_msg.json 1`] = `
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_to_registery: {
         new_pool_config: newPoolConfig
@@ -94,7 +94,7 @@ exports[`execute class /execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_pool_instance: {
         asset_infos: assetInfos,
@@ -119,7 +119,7 @@ exports[`execute class /execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       join_pool: {
         assets,
@@ -137,7 +137,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       swap: {
         recipient,
@@ -151,7 +151,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     expiresIn: number;
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         expires_in: expiresIn,
@@ -159,12 +159,12 @@ exports[`execute class /execute_msg.json 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  dropOwnershipProposal = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  dropOwnershipProposal = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       drop_ownership_proposal: {}
     }, fee_, memo_, funds_);
   };
-  claimOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  claimOwnership = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       claim_ownership: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
@@ -28,14 +28,14 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
         msg,
         sender
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateConfig = async ({
     feeCollector,
@@ -45,14 +45,14 @@ exports[`execute class /execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         fee_collector: feeCollector,
         generator_address: generatorAddress,
         lp_token_code_id: lpTokenCodeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updatePoolConfig = async ({
     isDisabled,
@@ -62,25 +62,25 @@ exports[`execute class /execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_pool_config: {
         is_disabled: isDisabled,
         new_fee_info: newFeeInfo,
         pool_type: poolType
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addToRegistery = async ({
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_to_registery: {
         new_pool_config: newPoolConfig
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createPoolInstance = async ({
     assetInfos,
@@ -94,7 +94,7 @@ exports[`execute class /execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_pool_instance: {
         asset_infos: assetInfos,
@@ -103,7 +103,7 @@ exports[`execute class /execute_msg.json 1`] = `
         lp_token_symbol: lpTokenSymbol,
         pool_type: poolType
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   joinPool = async ({
     assets,
@@ -119,7 +119,7 @@ exports[`execute class /execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       join_pool: {
         assets,
@@ -129,7 +129,7 @@ exports[`execute class /execute_msg.json 1`] = `
         recipient,
         slippage_tolerance: slippageTolerance
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   swap = async ({
     recipient,
@@ -137,13 +137,13 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       swap: {
         recipient,
         swap_request: swapRequest
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   proposeNewOwner = async ({
     expiresIn,
@@ -151,23 +151,23 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     expiresIn: number;
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         expires_in: expiresIn,
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  dropOwnershipProposal = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  dropOwnershipProposal = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       drop_ownership_proposal: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  claimOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  claimOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       claim_ownership: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -184,7 +184,7 @@ exports[`execute interface /execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     feeCollector,
     generatorAddress,
@@ -193,7 +193,7 @@ exports[`execute interface /execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updatePoolConfig: ({
     isDisabled,
     newFeeInfo,
@@ -202,12 +202,12 @@ exports[`execute interface /execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addToRegistery: ({
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createPoolInstance: ({
     assetInfos,
     initParams,
@@ -220,7 +220,7 @@ exports[`execute interface /execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   joinPool: ({
     assets,
     autoStake,
@@ -235,23 +235,23 @@ exports[`execute interface /execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   swap: ({
     recipient,
     swapRequest
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   proposeNewOwner: ({
     expiresIn,
     owner
   }: {
     expiresIn: number;
     owner: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  dropOwnershipProposal: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  claimOwnership: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  dropOwnershipProposal: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  claimOwnership: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-71.test.ts.snap
@@ -28,7 +28,7 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: Uint128;
     msg: Binary;
     sender: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       receive: {
         amount,
@@ -45,7 +45,7 @@ exports[`execute class /execute_msg.json 1`] = `
     feeCollector?: string;
     generatorAddress?: string;
     lpTokenCodeId?: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         fee_collector: feeCollector,
@@ -62,7 +62,7 @@ exports[`execute class /execute_msg.json 1`] = `
     isDisabled?: boolean;
     newFeeInfo?: FeeInfo;
     poolType: PoolType;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_pool_config: {
         is_disabled: isDisabled,
@@ -75,7 +75,7 @@ exports[`execute class /execute_msg.json 1`] = `
     newPoolConfig
   }: {
     newPoolConfig: PoolConfig;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_to_registery: {
         new_pool_config: newPoolConfig
@@ -94,7 +94,7 @@ exports[`execute class /execute_msg.json 1`] = `
     lpTokenName?: string;
     lpTokenSymbol?: string;
     poolType: PoolType;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_pool_instance: {
         asset_infos: assetInfos,
@@ -119,7 +119,7 @@ exports[`execute class /execute_msg.json 1`] = `
     poolId: Uint128;
     recipient?: string;
     slippageTolerance?: Decimal;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       join_pool: {
         assets,
@@ -137,7 +137,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     recipient?: string;
     swapRequest: SingleSwapRequest;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       swap: {
         recipient,
@@ -151,7 +151,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     expiresIn: number;
     owner: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       propose_new_owner: {
         expires_in: expiresIn,
@@ -159,12 +159,12 @@ exports[`execute class /execute_msg.json 1`] = `
       }
     }, fee_, memo_, funds_);
   };
-  dropOwnershipProposal = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  dropOwnershipProposal = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       drop_ownership_proposal: {}
     }, fee_, memo_, funds_);
   };
-  claimOwnership = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  claimOwnership = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       claim_ownership: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
@@ -13,10 +13,10 @@ exports[`execute classes array types 1`] = `
     this.getPlugins = this.getPlugins.bind(this);
     this.getPluginById = this.getPluginById.bind(this);
   }
-  getConfig = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  getConfig = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_config: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getPlugins = async ({
     limit,
@@ -24,24 +24,24 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugins: {
         limit,
         start_after: startAfter
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getPluginById = async ({
     id
   }: {
     id: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugin_by_id: {
         id
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -50,19 +50,19 @@ exports[`execute interfaces no extends 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  getConfig: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  getConfig: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getPlugins: ({
     limit,
     startAfter
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getPluginById: ({
     id
   }: {
     id: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
@@ -13,7 +13,7 @@ exports[`execute classes array types 1`] = `
     this.getPlugins = this.getPlugins.bind(this);
     this.getPluginById = this.getPluginById.bind(this);
   }
-  getConfig = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getConfig = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_config: {}
     }, fee_, memo_, funds_);
@@ -24,7 +24,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugins: {
         limit,
@@ -36,7 +36,7 @@ exports[`execute classes array types 1`] = `
     id
   }: {
     id: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugin_by_id: {
         id

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issue-98.test.ts.snap
@@ -13,7 +13,7 @@ exports[`execute classes array types 1`] = `
     this.getPlugins = this.getPlugins.bind(this);
     this.getPluginById = this.getPluginById.bind(this);
   }
-  getConfig = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getConfig = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_config: {}
     }, fee_, memo_, funds_);
@@ -24,7 +24,7 @@ exports[`execute classes array types 1`] = `
   }: {
     limit?: number;
     startAfter?: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugins: {
         limit,
@@ -36,7 +36,7 @@ exports[`execute classes array types 1`] = `
     id
   }: {
     id: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_plugin_by_id: {
         id

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
@@ -69,7 +69,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
@@ -85,7 +85,7 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
@@ -98,7 +98,7 @@ exports[`execute class /execute_msg.json 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
@@ -109,7 +109,7 @@ exports[`execute class /execute_msg.json 1`] = `
     graph
   }: {
     graph: Edge[];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
@@ -122,7 +122,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
@@ -136,7 +136,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
@@ -148,7 +148,7 @@ exports[`execute class /execute_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
@@ -159,14 +159,14 @@ exports[`execute class /execute_msg.json 1`] = `
     edges
   }: {
     edges: number[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
     }, fee_, memo_, funds_);
   };
-  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
     }, fee_, memo_, funds_);
@@ -175,14 +175,14 @@ exports[`execute class /execute_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  reset = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
     }, fee_, memo_, funds_);
@@ -191,7 +191,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
@@ -202,7 +202,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
@@ -213,7 +213,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
@@ -271,17 +271,17 @@ exports[`execute class /query_msg.json 1`] = `
     this.getTotalDebtByGraph = this.getTotalDebtByGraph.bind(this);
     this.getTotalDebt = this.getTotalDebt.bind(this);
   }
-  getDenom = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getDenom = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_denom: {}
     }, fee_, memo_, funds_);
   };
-  getOwner = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getOwner = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_owner: {}
     }, fee_, memo_, funds_);
   };
-  allEdges = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  allEdges = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_edges: {}
     }, fee_, memo_, funds_);
@@ -290,7 +290,7 @@ exports[`execute class /query_msg.json 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_edge: {
         edge_id: edgeId
@@ -301,7 +301,7 @@ exports[`execute class /query_msg.json 1`] = `
     batchId
   }: {
     batchId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_batch: {
         batch_id: batchId
@@ -312,7 +312,7 @@ exports[`execute class /query_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_graph: {
         graph_id: graphId
@@ -323,7 +323,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_by_address: {
         address
@@ -334,7 +334,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_as_counterparty: {
         address
@@ -345,7 +345,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_per_address: {
         address
@@ -356,7 +356,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_credit_per_address: {
         address
@@ -367,14 +367,14 @@ exports[`execute class /query_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_by_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  getTotalDebt = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getTotalDebt = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
@@ -69,13 +69,13 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
         creditor
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   editEdge = async ({
     amount,
@@ -85,36 +85,36 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
         creditor,
         edge_id: edgeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraph = async ({
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraphSimplified = async ({
     graph,
@@ -122,13 +122,13 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   editGraphSimplified = async ({
     graph,
@@ -136,89 +136,89 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateEdges = async ({
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   findSavingsInAGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   saveNetworkToFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   createGraphFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   applySetOffFromFile = async ({
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -271,113 +271,113 @@ exports[`execute class /query_msg.json 1`] = `
     this.getTotalDebtByGraph = this.getTotalDebtByGraph.bind(this);
     this.getTotalDebt = this.getTotalDebt.bind(this);
   }
-  getDenom = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  getDenom = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_denom: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  getOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  getOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_owner: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  allEdges = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  allEdges = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_edges: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   oneEdge = async ({
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_edge: {
         edge_id: edgeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   oneBatch = async ({
     batchId
   }: {
     batchId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_batch: {
         batch_id: batchId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   oneGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getEdgesByAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_by_address: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getEdgesAsCounterparty = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_as_counterparty: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getTotalDebtPerAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_per_address: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getTotalCreditPerAddress = async ({
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_credit_per_address: {
         address
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   getTotalDebtByGraph = async ({
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_by_graph: {
         graph_id: graphId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  getTotalDebt = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  getTotalDebt = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -413,7 +413,7 @@ exports[`execute interface /execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   editEdge: ({
     amount,
     creditor,
@@ -422,63 +422,63 @@ exports[`execute interface /execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraph: ({
     graph
   }: {
     graph: Edge[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   editGraphSimplified: ({
     graph,
     graphId
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateEdges: ({
     edges
   }: {
     edges: number[][];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  findSavings: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  findSavings: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   findSavingsInAGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  reset: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  reset: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   saveNetworkToFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   createGraphFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   applySetOffFromFile: ({
     filepath
   }: {
     filepath: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 
@@ -500,50 +500,50 @@ exports[`execute interface /query_msg.json 1`] = `
 "export interface SG721Instance {
   contractAddress: string;
   sender: string;
-  getDenom: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  getOwner: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  allEdges: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  getDenom: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  getOwner: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  allEdges: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   oneEdge: ({
     edgeId
   }: {
     edgeId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   oneBatch: ({
     batchId
   }: {
     batchId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   oneGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getEdgesByAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getEdgesAsCounterparty: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getTotalDebtPerAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getTotalCreditPerAddress: ({
     address
   }: {
     address: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   getTotalDebtByGraph: ({
     graphId
   }: {
     graphId: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  getTotalDebt: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  getTotalDebt: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.issues.test.ts.snap
@@ -69,7 +69,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     amount: number;
     creditor: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_edge: {
         amount,
@@ -85,7 +85,7 @@ exports[`execute class /execute_msg.json 1`] = `
     amount: number;
     creditor: Addr;
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_edge: {
         amount,
@@ -98,7 +98,7 @@ exports[`execute class /execute_msg.json 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_edge: {
         edge_id: edgeId
@@ -109,7 +109,7 @@ exports[`execute class /execute_msg.json 1`] = `
     graph
   }: {
     graph: Edge[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph: {
         graph
@@ -122,7 +122,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_simplified: {
         graph,
@@ -136,7 +136,7 @@ exports[`execute class /execute_msg.json 1`] = `
   }: {
     graph: Addr[][];
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       edit_graph_simplified: {
         graph,
@@ -148,7 +148,7 @@ exports[`execute class /execute_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_graph: {
         graph_id: graphId
@@ -159,14 +159,14 @@ exports[`execute class /execute_msg.json 1`] = `
     edges
   }: {
     edges: number[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_edges: {
         edges
       }
     }, fee_, memo_, funds_);
   };
-  findSavings = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  findSavings = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings: {}
     }, fee_, memo_, funds_);
@@ -175,14 +175,14 @@ exports[`execute class /execute_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       find_savings_in_a_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  reset = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  reset = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       reset: {}
     }, fee_, memo_, funds_);
@@ -191,7 +191,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       save_network_to_file: {
         filepath
@@ -202,7 +202,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       create_graph_from_file: {
         filepath
@@ -213,7 +213,7 @@ exports[`execute class /execute_msg.json 1`] = `
     filepath
   }: {
     filepath: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       apply_set_off_from_file: {
         filepath
@@ -271,17 +271,17 @@ exports[`execute class /query_msg.json 1`] = `
     this.getTotalDebtByGraph = this.getTotalDebtByGraph.bind(this);
     this.getTotalDebt = this.getTotalDebt.bind(this);
   }
-  getDenom = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getDenom = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_denom: {}
     }, fee_, memo_, funds_);
   };
-  getOwner = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getOwner = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_owner: {}
     }, fee_, memo_, funds_);
   };
-  allEdges = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  allEdges = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       all_edges: {}
     }, fee_, memo_, funds_);
@@ -290,7 +290,7 @@ exports[`execute class /query_msg.json 1`] = `
     edgeId
   }: {
     edgeId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_edge: {
         edge_id: edgeId
@@ -301,7 +301,7 @@ exports[`execute class /query_msg.json 1`] = `
     batchId
   }: {
     batchId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_batch: {
         batch_id: batchId
@@ -312,7 +312,7 @@ exports[`execute class /query_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       one_graph: {
         graph_id: graphId
@@ -323,7 +323,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_by_address: {
         address
@@ -334,7 +334,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_edges_as_counterparty: {
         address
@@ -345,7 +345,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_per_address: {
         address
@@ -356,7 +356,7 @@ exports[`execute class /query_msg.json 1`] = `
     address
   }: {
     address: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_credit_per_address: {
         address
@@ -367,14 +367,14 @@ exports[`execute class /query_msg.json 1`] = `
     graphId
   }: {
     graphId: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt_by_graph: {
         graph_id: graphId
       }
     }, fee_, memo_, funds_);
   };
-  getTotalDebt = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  getTotalDebt = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       get_total_debt: {}
     }, fee_, memo_, funds_);

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
@@ -25,13 +25,13 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -41,14 +41,14 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -58,14 +58,14 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -73,13 +73,13 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -87,24 +87,24 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -116,7 +116,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -124,18 +124,18 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -164,13 +164,13 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -180,14 +180,14 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -197,14 +197,14 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -212,13 +212,13 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -226,24 +226,24 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -255,7 +255,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -263,18 +263,18 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -304,13 +304,13 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -320,14 +320,14 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -337,14 +337,14 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -352,13 +352,13 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -366,24 +366,24 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -395,7 +395,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -403,18 +403,18 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -444,13 +444,13 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -460,14 +460,14 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -477,14 +477,14 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -492,13 +492,13 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -506,24 +506,24 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -535,7 +535,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -543,18 +543,18 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -583,13 +583,13 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -599,14 +599,14 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -616,14 +616,14 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -631,13 +631,13 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -645,24 +645,24 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -674,7 +674,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -682,18 +682,18 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -41,7 +41,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -58,7 +58,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -73,7 +73,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -87,7 +87,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -99,7 +99,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -116,7 +116,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -130,7 +130,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -164,7 +164,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -180,7 +180,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -197,7 +197,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -212,7 +212,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -226,7 +226,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -238,7 +238,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -255,7 +255,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -269,7 +269,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -304,7 +304,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -320,7 +320,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -337,7 +337,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -352,7 +352,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -366,7 +366,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -378,7 +378,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -395,7 +395,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -409,7 +409,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -444,7 +444,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -460,7 +460,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -477,7 +477,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -492,7 +492,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -506,7 +506,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -518,7 +518,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -535,7 +535,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -549,7 +549,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -583,7 +583,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -599,7 +599,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -616,7 +616,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -631,7 +631,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -645,7 +645,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -657,7 +657,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -674,7 +674,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -688,7 +688,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.overrides.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -41,7 +41,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -58,7 +58,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -73,7 +73,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -87,7 +87,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -99,7 +99,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -116,7 +116,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -130,7 +130,7 @@ exports[`Impl, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -164,7 +164,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -180,7 +180,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -197,7 +197,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -212,7 +212,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -226,7 +226,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -238,7 +238,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -255,7 +255,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -269,7 +269,7 @@ exports[`Impl, execExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -304,7 +304,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -320,7 +320,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -337,7 +337,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -352,7 +352,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -366,7 +366,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -378,7 +378,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -395,7 +395,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -409,7 +409,7 @@ exports[`noImpl, execExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -444,7 +444,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -460,7 +460,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -477,7 +477,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -492,7 +492,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -506,7 +506,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -518,7 +518,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -535,7 +535,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -549,7 +549,7 @@ exports[`noImpl, noExecExtends, ExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -583,7 +583,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -599,7 +599,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -616,7 +616,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -631,7 +631,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -645,7 +645,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -657,7 +657,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -674,7 +674,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -688,7 +688,7 @@ exports[`noImpl, noExecExtends, noExtendsClass 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
@@ -24,7 +24,7 @@ exports[`execute classes array types 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -40,7 +40,7 @@ exports[`execute classes array types 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -57,7 +57,7 @@ exports[`execute classes array types 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -72,7 +72,7 @@ exports[`execute classes array types 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -86,7 +86,7 @@ exports[`execute classes array types 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -98,7 +98,7 @@ exports[`execute classes array types 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -115,7 +115,7 @@ exports[`execute classes array types 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -129,7 +129,7 @@ exports[`execute classes array types 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
@@ -24,7 +24,7 @@ exports[`execute classes array types 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -40,7 +40,7 @@ exports[`execute classes array types 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -57,7 +57,7 @@ exports[`execute classes array types 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -72,7 +72,7 @@ exports[`execute classes array types 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -86,7 +86,7 @@ exports[`execute classes array types 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -98,7 +98,7 @@ exports[`execute classes array types 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -115,7 +115,7 @@ exports[`execute classes array types 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -129,7 +129,7 @@ exports[`execute classes array types 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.sg721.test.ts.snap
@@ -24,13 +24,13 @@ exports[`execute classes array types 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -40,14 +40,14 @@ exports[`execute classes array types 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -57,14 +57,14 @@ exports[`execute classes array types 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -72,13 +72,13 @@ exports[`execute classes array types 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -86,24 +86,24 @@ exports[`execute classes array types 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -115,7 +115,7 @@ exports[`execute classes array types 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -123,18 +123,18 @@ exports[`execute classes array types 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -149,7 +149,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -158,7 +158,7 @@ exports[`execute interfaces no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -167,26 +167,26 @@ exports[`execute interfaces no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -197,12 +197,12 @@ exports[`execute interfaces no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
@@ -61,7 +61,7 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -77,7 +77,7 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -94,7 +94,7 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -109,7 +109,7 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -123,7 +123,7 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -135,7 +135,7 @@ exports[`execute classes 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -152,7 +152,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -166,7 +166,7 @@ exports[`execute classes 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -197,7 +197,7 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
@@ -210,7 +210,7 @@ exports[`execute classes array types 1`] = `
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
@@ -221,7 +221,7 @@ exports[`execute classes array types 1`] = `
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
@@ -255,7 +255,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -271,7 +271,7 @@ exports[`execute classes no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -288,7 +288,7 @@ exports[`execute classes no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -303,7 +303,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -317,7 +317,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -329,7 +329,7 @@ exports[`execute classes no extends 1`] = `
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -346,7 +346,7 @@ exports[`execute classes no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -360,7 +360,7 @@ exports[`execute classes no extends 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
@@ -61,13 +61,13 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -77,14 +77,14 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -94,14 +94,14 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -109,13 +109,13 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -123,24 +123,24 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -152,7 +152,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -160,18 +160,18 @@ exports[`execute classes 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -197,36 +197,36 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
         addresses_to_remove: addressesToRemove,
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeGroup = async ({
     group
   }: {
     group: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateOwner = async ({
     owner
   }: {
     owner: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -255,13 +255,13 @@ exports[`execute classes no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   sendNft = async ({
     contract,
@@ -271,14 +271,14 @@ exports[`execute classes no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
         msg,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approve = async ({
     expires,
@@ -288,14 +288,14 @@ exports[`execute classes no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revoke = async ({
     spender,
@@ -303,13 +303,13 @@ exports[`execute classes no extends 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   approveAll = async ({
     expires,
@@ -317,24 +317,24 @@ exports[`execute classes no extends 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   revokeAll = async ({
     operator
   }: {
     operator: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   mint = async ({
     extension,
@@ -346,7 +346,7 @@ exports[`execute classes no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -354,18 +354,18 @@ exports[`execute classes no extends 1`] = `
         token_id: tokenId,
         token_uri: tokenUri
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   burn = async ({
     tokenId
   }: {
     tokenId: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -380,7 +380,7 @@ exports[`execute interfaces no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   sendNft: ({
     contract,
     msg,
@@ -389,7 +389,7 @@ exports[`execute interfaces no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approve: ({
     expires,
     spender,
@@ -398,26 +398,26 @@ exports[`execute interfaces no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   mint: ({
     extension,
     owner,
@@ -428,12 +428,12 @@ exports[`execute interfaces no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.test.ts.snap
@@ -61,7 +61,7 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -77,7 +77,7 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -94,7 +94,7 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -109,7 +109,7 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -123,7 +123,7 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -135,7 +135,7 @@ exports[`execute classes 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -152,7 +152,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -166,7 +166,7 @@ exports[`execute classes 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId
@@ -197,7 +197,7 @@ exports[`execute classes array types 1`] = `
     addressesToAdd?: string[];
     addressesToRemove?: string[];
     group: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update: {
         addresses_to_add: addressesToAdd,
@@ -210,7 +210,7 @@ exports[`execute classes array types 1`] = `
     group
   }: {
     group: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_group: {
         group
@@ -221,7 +221,7 @@ exports[`execute classes array types 1`] = `
     owner
   }: {
     owner: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         owner
@@ -255,7 +255,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       transfer_nft: {
         recipient,
@@ -271,7 +271,7 @@ exports[`execute classes no extends 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       send_nft: {
         contract,
@@ -288,7 +288,7 @@ exports[`execute classes no extends 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve: {
         expires,
@@ -303,7 +303,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke: {
         spender,
@@ -317,7 +317,7 @@ exports[`execute classes no extends 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       approve_all: {
         expires,
@@ -329,7 +329,7 @@ exports[`execute classes no extends 1`] = `
     operator
   }: {
     operator: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revoke_all: {
         operator
@@ -346,7 +346,7 @@ exports[`execute classes no extends 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       mint: {
         extension,
@@ -360,7 +360,7 @@ exports[`execute classes no extends 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       burn: {
         token_id: tokenId

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
@@ -30,14 +30,14 @@ exports[`execute classes array types 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
     }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
     }, fee_, memo_, funds_);
@@ -46,7 +46,7 @@ exports[`execute classes array types 1`] = `
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
@@ -57,7 +57,7 @@ exports[`execute classes array types 1`] = `
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
@@ -68,7 +68,7 @@ exports[`execute classes array types 1`] = `
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
@@ -79,7 +79,7 @@ exports[`execute classes array types 1`] = `
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
@@ -92,7 +92,7 @@ exports[`execute classes array types 1`] = `
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
@@ -104,7 +104,7 @@ exports[`execute classes array types 1`] = `
     newLabel
   }: {
     newLabel: string;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
@@ -30,14 +30,14 @@ exports[`execute classes array types 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
     }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
     }, fee_, memo_, funds_);
@@ -46,7 +46,7 @@ exports[`execute classes array types 1`] = `
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
@@ -57,7 +57,7 @@ exports[`execute classes array types 1`] = `
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
@@ -68,7 +68,7 @@ exports[`execute classes array types 1`] = `
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
@@ -79,7 +79,7 @@ exports[`execute classes array types 1`] = `
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
@@ -92,7 +92,7 @@ exports[`execute classes array types 1`] = `
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
@@ -104,7 +104,7 @@ exports[`execute classes array types 1`] = `
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.vectis.test.ts.snap
@@ -30,61 +30,61 @@ exports[`execute classes array types 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       execute: {
         msgs
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
-  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  revertFreezeStatus = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       revert_freeze_status: {}
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   relay = async ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       relay: {
         transaction
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   rotateUserKey = async ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       rotate_user_key: {
         new_user_address: newUserAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   addRelayer = async ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       add_relayer: {
         new_relayer_address: newRelayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   removeRelayer = async ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_relayer: {
         relayer_address: relayerAddress
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateGuardians = async ({
     guardians,
@@ -92,24 +92,24 @@ exports[`execute classes array types 1`] = `
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_guardians: {
         guardians,
         new_multisig_code_id: newMultisigCodeId
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   updateLabel = async ({
     newLabel
   }: {
     newLabel: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_label: {
         new_label: newLabel
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;
@@ -122,40 +122,40 @@ exports[`execute interfaces no extends 1`] = `
     msgs
   }: {
     msgs: CosmosMsg_for_Empty[];
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
-  revertFreezeStatus: (fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
+  revertFreezeStatus: (fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   relay: ({
     transaction
   }: {
     transaction: RelayTransaction;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   rotateUserKey: ({
     newUserAddress
   }: {
     newUserAddress: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   addRelayer: ({
     newRelayerAddress
   }: {
     newRelayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   removeRelayer: ({
     relayerAddress
   }: {
     relayerAddress: Addr;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateGuardians: ({
     guardians,
     newMultisigCodeId
   }: {
     guardians: Guardians;
     newMultisigCodeId?: number;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
   updateLabel: ({
     newLabel
   }: {
     newLabel: string;
-  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  }, fee_?: number | StdFee | "auto", memo_?: string, funds_?: Coin[]) => Promise<ExecuteResult>;
 }"
 `;
 

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
@@ -20,7 +20,7 @@ exports[`execute classes 1`] = `
     params
   }: {
     params: ParamInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         params
@@ -35,7 +35,7 @@ exports[`execute classes 1`] = `
     currentPrices: number[][];
     prevPrices: number[][];
     wagerKey: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_winner: {
         current_prices: currentPrices,
@@ -54,7 +54,7 @@ exports[`execute classes 1`] = `
     currency: Currency;
     expiry: number;
     token: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       wager: {
         against_currencies: againstCurrencies,
@@ -68,7 +68,7 @@ exports[`execute classes 1`] = `
     token
   }: {
     token: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cancel: {
         token

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
@@ -20,7 +20,7 @@ exports[`execute classes 1`] = `
     params
   }: {
     params: ParamInfo;
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         params
@@ -35,7 +35,7 @@ exports[`execute classes 1`] = `
     currentPrices: number[][];
     prevPrices: number[][];
     wagerKey: Addr[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_winner: {
         current_prices: currentPrices,
@@ -54,7 +54,7 @@ exports[`execute classes 1`] = `
     currency: Currency;
     expiry: number;
     token: Addr[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       wager: {
         against_currencies: againstCurrencies,
@@ -68,7 +68,7 @@ exports[`execute classes 1`] = `
     token
   }: {
     token: Addr[][];
-  }, fee_: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
+  }, fee_: number | StdFee | "auto" = "auto", memo_?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cancel: {
         token

--- a/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
+++ b/packages/ast/__tests__/client/__snapshots__/ts-client.wager.test.ts.snap
@@ -20,12 +20,12 @@ exports[`execute classes 1`] = `
     params
   }: {
     params: ParamInfo;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         params
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   setWinner = async ({
     currentPrices,
@@ -35,14 +35,14 @@ exports[`execute classes 1`] = `
     currentPrices: number[][];
     prevPrices: number[][];
     wagerKey: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       set_winner: {
         current_prices: currentPrices,
         prev_prices: prevPrices,
         wager_key: wagerKey
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   wager = async ({
     againstCurrencies,
@@ -54,7 +54,7 @@ exports[`execute classes 1`] = `
     currency: Currency;
     expiry: number;
     token: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       wager: {
         against_currencies: againstCurrencies,
@@ -62,18 +62,18 @@ exports[`execute classes 1`] = `
         expiry,
         token
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
   cancel = async ({
     token
   }: {
     token: Addr[][];
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds_?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       cancel: {
         token
       }
-    }, fee, memo, _funds);
+    }, fee_, memo_, funds_);
   };
 }"
 `;

--- a/packages/ast/__tests__/message-composer/__snapshots__/message-composer.test.ts.snap
+++ b/packages/ast/__tests__/message-composer/__snapshots__/message-composer.test.ts.snap
@@ -10,7 +10,7 @@ exports[`createMessageComposerInterface 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   sendNft: ({
     contract,
     msg,
@@ -19,7 +19,7 @@ exports[`createMessageComposerInterface 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approve: ({
     expires,
     spender,
@@ -28,26 +28,26 @@ exports[`createMessageComposerInterface 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revoke: ({
     spender,
     tokenId
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   approveAll: ({
     expires,
     operator
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   revokeAll: ({
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   mint: ({
     extension,
     owner,
@@ -58,12 +58,12 @@ exports[`createMessageComposerInterface 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
   burn: ({
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }"
 `;
 
@@ -89,7 +89,7 @@ exports[`execute classes 1`] = `
   }: {
     recipient: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -101,7 +101,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -113,7 +113,7 @@ exports[`execute classes 1`] = `
     contract: string;
     msg: Binary;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -126,7 +126,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -138,7 +138,7 @@ exports[`execute classes 1`] = `
     expires?: Expiration;
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -151,7 +151,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -161,7 +161,7 @@ exports[`execute classes 1`] = `
   }: {
     spender: string;
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -173,7 +173,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -183,7 +183,7 @@ exports[`execute classes 1`] = `
   }: {
     expires?: Expiration;
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -195,7 +195,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -203,7 +203,7 @@ exports[`execute classes 1`] = `
     operator
   }: {
     operator: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -214,7 +214,7 @@ exports[`execute classes 1`] = `
             operator
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -228,7 +228,7 @@ exports[`execute classes 1`] = `
     owner: string;
     tokenId: string;
     tokenUri?: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -242,7 +242,7 @@ exports[`execute classes 1`] = `
             token_uri: tokenUri
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -250,7 +250,7 @@ exports[`execute classes 1`] = `
     tokenId
   }: {
     tokenId: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -261,7 +261,7 @@ exports[`execute classes 1`] = `
             token_id: tokenId
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -282,7 +282,7 @@ exports[`ownershipClass 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  }, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -293,11 +293,11 @@ exports[`ownershipClass 1`] = `
             new_factory: newFactory
           }
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
-  updateOwnership = (action: Action, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+  updateOwnership = (action: Action, funds_?: Coin[]): MsgExecuteContractEncodeObject => {
     return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
@@ -306,7 +306,7 @@ exports[`ownershipClass 1`] = `
         msg: toUtf8(JSON.stringify({
           update_ownership: action
         })),
-        funds: _funds
+        funds: funds_
       })
     };
   };
@@ -321,7 +321,7 @@ exports[`ownershipInterface 1`] = `
     newFactory
   }: {
     newFactory: string;
-  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
-  updateOwnership: (action: Action, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  }, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
+  updateOwnership: (action: Action, funds_?: Coin[]) => MsgExecuteContractEncodeObject;
 }"
 `;

--- a/packages/ast/src/client/client.ts
+++ b/packages/ast/src/client/client.ts
@@ -38,7 +38,7 @@ export const CONSTANT_EXEC_PARAMS = [
     ),
     t.stringLiteral('auto')
   ),
-  identifier('memo', t.tsTypeAnnotation(t.tsStringKeyword()), true),
+  OPTIONAL_MEMO_PARAM,
   OPTIONAL_FUNDS_PARAM
 ];
 

--- a/packages/ast/src/client/client.ts
+++ b/packages/ast/src/client/client.ts
@@ -266,9 +266,9 @@ export const createWasmExecMethod = (
                 t.objectExpression([
                   t.objectProperty(msgAction, msgActionValue)
                 ]),
-                t.identifier('fee'),
-                t.identifier('memo'),
-                t.identifier('_funds')
+                t.identifier('fee_'),
+                t.identifier('memo_'),
+                t.identifier('funds_')
               ]
             )
           )

--- a/packages/ast/src/client/client.ts
+++ b/packages/ast/src/client/client.ts
@@ -21,11 +21,12 @@ import {
   getPropertyType,
   getResponseType
 } from '../utils/types';
+import { OPTIONAL_FEE_PARAM, OPTIONAL_MEMO_PARAM } from "../utils/constants";
 
 export const CONSTANT_EXEC_PARAMS = [
   t.assignmentPattern(
     identifier(
-      'fee',
+      'fee_',
       t.tsTypeAnnotation(
         t.tsUnionType([
           t.tSNumberKeyword(),

--- a/packages/ast/src/client/client.ts
+++ b/packages/ast/src/client/client.ts
@@ -21,7 +21,7 @@ import {
   getPropertyType,
   getResponseType
 } from '../utils/types';
-import { OPTIONAL_FEE_PARAM, OPTIONAL_MEMO_PARAM } from "../utils/constants";
+import { OPTIONAL_MEMO_PARAM } from "../utils/constants";
 
 export const CONSTANT_EXEC_PARAMS = [
   t.assignmentPattern(

--- a/packages/ast/src/context/context.ts
+++ b/packages/ast/src/context/context.ts
@@ -100,7 +100,7 @@ export class BuilderContext {
     [key: string]: {
       [key: string]: ProviderInfo;
     };
-  } {
+    } {
     return this.providers;
   }
 }
@@ -145,7 +145,7 @@ export abstract class RenderContextBase<TOpt = RenderOptions> implements IRender
     [key: string]: {
       [key: string]: ProviderInfo;
     };
-  } {
+    } {
     return this.builderContext.providers;
   }
   getImports(registeredUtils?: UtilMapping, filepath?: string): (t.ImportNamespaceSpecifier | t.ImportDeclaration | t.ImportDefaultSpecifier)[] {

--- a/packages/ast/src/message-composer/message-composer.ts
+++ b/packages/ast/src/message-composer/message-composer.ts
@@ -107,7 +107,7 @@ const createWasmExecMethodMessageComposer = (
                     ),
                     t.objectProperty(
                       t.identifier('funds'),
-                      t.identifier('_funds')
+                      t.identifier('funds_')
                     )
                   ])
                 ]

--- a/packages/ast/src/utils/babel.ts
+++ b/packages/ast/src/utils/babel.ts
@@ -97,18 +97,18 @@ export const bindMethod = (name: string) => {
       t.thisExpression(),
       t.identifier(name)
     ),
-      t.callExpression(
+    t.callExpression(
+      t.memberExpression(
         t.memberExpression(
-          t.memberExpression(
-            t.thisExpression(),
-            t.identifier(name)
-          ),
-          t.identifier('bind')
+          t.thisExpression(),
+          t.identifier(name)
         ),
-        [
-          t.thisExpression()
-        ]
-      )
+        t.identifier('bind')
+      ),
+      [
+        t.thisExpression()
+      ]
+    )
     )
   );
 };

--- a/packages/ast/src/utils/constants.ts
+++ b/packages/ast/src/utils/constants.ts
@@ -3,12 +3,12 @@ import * as t from '@babel/types';
 import { identifier } from './babel';
 
 export const OPTIONAL_FUNDS_PARAM = identifier(
-  '_funds',
+  'funds_',
   t.tsTypeAnnotation(t.tsArrayType(t.tsTypeReference(t.identifier('Coin')))),
   true
 );
 export const OPTIONAL_FEE_PARAM = identifier(
-  'fee',
+  'fee_',
   t.tsTypeAnnotation(
     t.tsUnionType([
       t.tsNumberKeyword(),
@@ -19,7 +19,7 @@ export const OPTIONAL_FEE_PARAM = identifier(
   true
 );
 export const OPTIONAL_MEMO_PARAM = identifier(
-  'memo',
+  'memo_',
   t.tsTypeAnnotation(t.tsStringKeyword()),
   true
 );


### PR DESCRIPTION
Implements https://github.com/CosmWasm/ts-codegen/issues/113

This updates the generated parameters for fee, memo, and funds to be `fee_`, `memo_`, and `funds_` respectively due to possible conflicts with wasm messages. See #97 for an example.